### PR TITLE
Update 3-hpa-http-requests.yaml : Fixing metrics name to `http_requests_per_second`

### DIFF
--- a/lessons/073/5-demo/3-hpa-http-requests.yaml
+++ b/lessons/073/5-demo/3-hpa-http-requests.yaml
@@ -18,7 +18,7 @@ spec:
     pods:
       metric:
         # use the metric that you used above: pods/http_requests
-        name: http_requests
+        name: http_requests_per_second
       target:
         # target 500 milli-requests per second,
         # which is 1 request every two seconds


### PR DESCRIPTION
Fixing metrics name to `http_requests_per_second`