### PR TITLE
Autoscalar for AWS EKS v1.25

### DIFF
--- a/lessons/102/k8s/cluster-autoscaler.yaml
+++ b/lessons/102/k8s/cluster-autoscaler.yaml
@@ -2,6 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
   name: cluster-autoscaler
   namespace: kube-system
   annotations:
@@ -11,6 +14,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 rules:
   - apiGroups: [""]
     resources: ["events", "endpoints"]
@@ -29,7 +35,13 @@ rules:
     resources: ["nodes"]
     verbs: ["watch", "list", "get", "update"]
   - apiGroups: [""]
-    resources: ["namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"]
+    resources:
+      - "namespaces"
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
     verbs: ["watch", "list", "get"]
   - apiGroups: ["extensions"]
     resources: ["replicasets", "daemonsets"]
@@ -59,6 +71,9 @@ kind: Role
 metadata:
   name: cluster-autoscaler
   namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -67,11 +82,15 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
     verbs: ["delete", "get", "update", "watch"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -80,12 +99,16 @@ subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
     namespace: kube-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-autoscaler
   namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -94,6 +117,7 @@ subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
     namespace: kube-system
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -111,10 +135,20 @@ spec:
     metadata:
       labels:
         app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
     spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.1
           name: cluster-autoscaler
           resources:
             limits:
@@ -123,22 +157,25 @@ spec:
             requests:
               cpu: 100m
               memory: 600Mi
-          # https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md
-          command: 
+          command:
             - ./cluster-autoscaler
             - --v=4
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/demo # Update cluster
-            - --balance-similar-node-groups
-            - --skip-nodes-with-system-pods=false
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/demo
           volumeMounts:
             - name: ssl-certs
-              mountPath: /etc/ssl/certs/ca-certificates.crt
+              mountPath: /etc/ssl/certs/ca-certificates.crt #/etc/ssl/certs/ca-bundle.crt for Amazon Linux Worker Nodes
               readOnly: true
           imagePullPolicy: "Always"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
       volumes:
         - name: ssl-certs
           hostPath:

--- a/lessons/102/k8s/deployment.yaml
+++ b/lessons/102/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: nginx:1.23.4
         ports:
         - name: web
           containerPort: 80

--- a/lessons/102/terraform/6-eks.tf
+++ b/lessons/102/terraform/6-eks.tf
@@ -22,8 +22,15 @@ resource "aws_iam_role_policy_attachment" "demo-AmazonEKSClusterPolicy" {
   role       = aws_iam_role.demo.name
 }
 
+variable "cluster_name" {
+  default = "demo"
+  type = string
+  description = "AWS EKS CLuster Name"
+  nullable = false
+}
+
 resource "aws_eks_cluster" "demo" {
-  name     = "demo"
+  name     = var.cluster_name
   role_arn = aws_iam_role.demo.arn
 
   vpc_config {


### PR DESCRIPTION
Updated Terraform and Kubernetes manifests to support AWS EKS v1.25.
These changes are taken from [AWS autoscaling](https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html) webpage.

Also bumped NGINX version to use the [latest official image](https://hub.docker.com/_/nginx).