### PR TITLE
Use the latest EBS CSI driver addon

### DIFF
--- a/lessons/154/terraform/10-csi-driver-addon.tf
+++ b/lessons/154/terraform/10-csi-driver-addon.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_addon" "csi_driver" {
   cluster_name             = aws_eks_cluster.demo.name
   addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.15.0-eksbuild.1"
+  addon_version            = "v1.18.0-eksbuild.1"
   service_account_role_arn = aws_iam_role.eks_ebs_csi_driver.arn
 }


### PR DESCRIPTION
Get the latest versions of AWS EKS addons using:

```zsh
aws eks describe-addon-versions > eks_addons.json
```

and check for "aws-ebs-csi-driver". 

The current version of this driver is "v1.18.0-eksbuild.1". It supports Kubernetes v1.17+ through the current EKS version.

Repository:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver
