### PR TITLE
Update main.yaml

### DIFF
--- a/lessons/014/roles/nginx/tasks/main.yaml
+++ b/lessons/014/roles/nginx/tasks/main.yaml
@@ -1,8 +1,14 @@
 ---
+- name: Update package cache
+  become: yes
+  apt:
+    update_cache: yes
+
 - name: Ensure Nginx is at the latest version
   apt:
     name: nginx
     state: latest
+
 - name: Make sure Nginx is running
   systemd:
     state: started


### PR DESCRIPTION
avoid Errors on new AWS Ubuntu AMIs, need to update_cache like sudo apt update before trying to install Nginx, if not it won't the find its package in apt,.... Thanks btw