### PR TITLE
Lesson 203: Remove String to Uuid conversion to closely resemble go

### DIFF
--- a/lessons/203/rust-app/src/device.rs
+++ b/lessons/203/rust-app/src/device.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Device {
-    pub uuid: Uuid,
+    pub uuid: String,
     pub mac: String,
     pub firmware: String,
 }

--- a/lessons/203/rust-app/src/device.rs
+++ b/lessons/203/rust-app/src/device.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Device {

--- a/lessons/203/rust-app/src/main.rs
+++ b/lessons/203/rust-app/src/main.rs
@@ -7,8 +7,7 @@ use std::sync::Mutex;
 use actix_web::{get, App, HttpResponse, HttpServer};
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::{config::Region, primitives::ByteStream, Client};
-use std::path::Path;
-use uuid::uuid;
+use std::path::Path;    
 
 use actix_web::middleware::Compress;
 use actix_web::{web, Result};
@@ -43,27 +42,27 @@ async fn get_metrics(state: web::Data<Mutex<AppState>>) -> Result<HttpResponse> 
 async fn get_devices() -> HttpResponse {
     let devices = Vec::from([
         Device {
-            uuid: uuid!("b0e42fe7-31a5-4894-a441-007e5256afea"),
+            uuid: String::from("b0e42fe7-31a5-4894-a441-007e5256afea"),
             mac: String::from("5F-33-CC-1F-43-82"),
             firmware: String::from("2.1.6"),
         },
         Device {
-            uuid: uuid!("0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7"),
+            uuid: String::from("0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7"),
             mac: String::from("EF-2B-C4-F5-D6-34"),
             firmware: String::from("2.1.5"),
         },
         Device {
-            uuid: uuid!("b16d0b53-14f1-4c11-8e29-b9fcef167c26"),
+            uuid: String::from("b16d0b53-14f1-4c11-8e29-b9fcef167c26"),
             mac: String::from("62-46-13-B7-B3-A1"),
             firmware: String::from("3.0.0"),
         },
         Device {
-            uuid: uuid!("51bb1937-e005-4327-a3bd-9f32dcf00db8"),
+            uuid: String::from("51bb1937-e005-4327-a3bd-9f32dcf00db8"),
             mac: String::from("96-A8-DE-5B-77-14"),
             firmware: String::from("1.0.1"),
         },
         Device {
-            uuid: uuid!("e0a1d085-dce5-48db-a794-35640113fa67"),
+            uuid: String::from("e0a1d085-dce5-48db-a794-35640113fa67"),
             mac: String::from("7E-3B-62-A6-09-12"),
             firmware: String::from("3.5.6"),
         },


### PR DESCRIPTION
When hitting devices endpoint, it's a bit unfair as Rust has to do extra computation compared to Go from String to Uuid and then back Uuid to String when serializing.