### PR TITLE
A few Go improvements

### DIFF
--- a/lessons/205/go-app/images.go
+++ b/lessons/205/go-app/images.go
@@ -45,15 +45,12 @@ func NewImage() *Image {
 }
 
 // Save inserts a newly generated image into the Postgres database.
-func save(c *Image, table string, dbpool *pgxpool.Pool, m *metrics) error {
+func (i *Image) save(dbpool *pgxpool.Pool, m *metrics) error {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
 
-	// Prepare the database query to insert a record (unsafe).
-	query := fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3)", table)
-
 	// Execute the query to create a new image record (pgx automatically prepares and caches statements by default).
-	_, err := dbpool.Exec(context.Background(), query, c.ImageUUID, c.Key, c.CreatedAt)
+	_, err := dbpool.Exec(context.Background(), "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("dbpool.Exec failed: %w", err)
 	}

--- a/lessons/205/go-app/main.go
+++ b/lessons/205/go-app/main.go
@@ -123,7 +123,7 @@ func (ms *MyServer) getImage(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Save the image metadata to db.
-	err = save(image, "go_image", ms.db, ms.metrics)
+	err = image.save(ms.db, ms.metrics)
 	if err != nil {
 		log.Printf("save failed: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
1. The Go version was using a dynamic table name supplied as a function argument, which is not present in the Rust version and which requires an extra fmt.Sprintf to pre-prepare the query. I made it static to match the Rust version.
2. Made the image save() function a method on the Image type, which is more idiomatic Go, probably no performance difference but it's cleaner
3. Removed an unnecessary variable creation in NewImage() and assign the CreatedAt direction from  time.Now() 
4. Since the components of Key are all strings,  we should use string concatenation instead of fmt.Sprintf to create the Key.
