### PR TITLE
remove cow and add concurrent upload/save

### DIFF
--- a/lessons/203/rust-app-v2/src/device.rs
+++ b/lessons/203/rust-app-v2/src/device.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Device<'a> {
-    pub uuid: Cow<'a, str>,
-    pub mac: Cow<'a, str>,
-    pub firmware: Cow<'a, str>,
+    pub uuid: &'a str,
+    pub mac: &'a str,
+    pub firmware: &'a str,
 }

--- a/lessons/203/rust-app-v2/src/routes.rs
+++ b/lessons/203/rust-app-v2/src/routes.rs
@@ -6,29 +6,29 @@ use crate::{device::Device, image::Image, state::AppState};
 pub async fn devices() -> impl IntoResponse {
     let devices = [
         Device {
-            uuid: "b0e42fe7-31a5-4894-a441-007e5256afea".into(),
-            mac: "5F-33-CC-1F-43-82".into(),
-            firmware: "2.1.6".into(),
+            uuid: "b0e42fe7-31a5-4894-a441-007e5256afea",
+            mac: "5F-33-CC-1F-43-82",
+            firmware: "2.1.6",
         },
         Device {
-            uuid: "0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7".into(),
-            mac: "EF-2B-C4-F5-D6-34".into(),
-            firmware: "2.1.5".into(),
+            uuid: "0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7",
+            mac: "EF-2B-C4-F5-D6-34",
+            firmware: "2.1.5",
         },
         Device {
-            uuid: "b16d0b53-14f1-4c11-8e29-b9fcef167c26".into(),
-            mac: "62-46-13-B7-B3-A1".into(),
-            firmware: "3.0.0".into(),
+            uuid: "b16d0b53-14f1-4c11-8e29-b9fcef167c26",
+            mac: "62-46-13-B7-B3-A1",
+            firmware: "3.0.0",
         },
         Device {
-            uuid: "51bb1937-e005-4327-a3bd-9f32dcf00db8".into(),
-            mac: "96-A8-DE-5B-77-14".into(),
-            firmware: "1.0.1".into(),
+            uuid: "51bb1937-e005-4327-a3bd-9f32dcf00db8",
+            mac: "96-A8-DE-5B-77-14",
+            firmware: "1.0.1",
         },
         Device {
-            uuid: "e0a1d085-dce5-48db-a794-35640113fa67".into(),
-            mac: "7E-3B-62-A6-09-12".into(),
-            firmware: "3.5.6".into(),
+            uuid: "e0a1d085-dce5-48db-a794-35640113fa67",
+            mac: "7E-3B-62-A6-09-12",
+            firmware: "3.5.6",
         },
     ];
 


### PR DESCRIPTION
**Use static str for devices**

[Cow](https://doc.rust-lang.org/std/borrow/enum.Cow.html) adds unnecessary overhead.  We are creating and returning static strings with devices, never using the `Owned` enum variant.  With Cow, each device creates an enum that holds references to an  `Owned` memory location and/or a `Borrowed` memory location.  However, this program only uses `Borrowed` path.

Removing the overhead creates a small but measurable improvement.

Local stress test using Cow running `wrk -t12 -c400 -d30s http://localhost:8080/api/devices`
Requests/sec: 
171901.99
172399.36
172104.08

Using static strings
Requests/sec: 
173199.04
173038.07
172948.25

**Image save and upload concurrently**

No need to wait for image upload to happen before save (unless we want to).  Run them both at the same time with `tokio::join`
