### PR TITLE
[205] Increasing socket count

### DIFF
--- a/lessons/205/rust-app/Cargo.lock
+++ b/lessons/205/rust-app/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "serde",
+ "socket2",
  "tokio",
  "tokio-postgres",
  "toml",

--- a/lessons/205/rust-app/Cargo.toml
+++ b/lessons/205/rust-app/Cargo.toml
@@ -20,6 +20,7 @@ tokio-postgres = { version = "0.7.11", features = [
 ] }
 toml = "0.8.19"
 uuid = { version = "1.10.0", features = ["v4"] }
+socket2 = "0.5"
 
 [profile.release]
 lto = true

--- a/lessons/205/rust-app/src/main.rs
+++ b/lessons/205/rust-app/src/main.rs
@@ -5,7 +5,12 @@ mod metrics;
 mod routes;
 mod state;
 
-use std::{future::ready, io, net::{SocketAddr, ToSocketAddrs}, time::Duration};
+use std::{
+    future::ready,
+    io,
+    net::{SocketAddr, ToSocketAddrs},
+    time::Duration,
+};
 
 use axum::{http::StatusCode, routing::get, Router};
 use metrics::setup_metrics_recorder;
@@ -56,11 +61,11 @@ async fn main() {
 
     // Bind the server to the configured port.
     let listener = match create_listener(format!("0.0.0.0:{}", port)) {
-      Ok(listener) => listener,
-      Err(err) => {
-          eprintln!("Failed to bind to port {}: {:?}", port, err);
-          return;
-      }
+        Ok(listener) => listener,
+        Err(err) => {
+            eprintln!("Failed to bind to port {}: {:?}", port, err);
+            return;
+        }
     };
 
     // Start the server.
@@ -70,21 +75,21 @@ async fn main() {
 }
 
 fn create_listener<A: ToSocketAddrs>(addr: A) -> io::Result<tokio::net::TcpListener> {
-  let mut addrs = addr.to_socket_addrs()?;
-  let addr = addrs.next().unwrap();
-  let listener = match &addr {
-    SocketAddr::V4(_) => Socket::new(Domain::IPV4, Type::STREAM, None)?,
-    SocketAddr::V6(_) => Socket::new(Domain::IPV6, Type::STREAM, None)?,
-  };
+    let mut addrs = addr.to_socket_addrs()?;
+    let addr = addrs.next().unwrap();
+    let listener = match &addr {
+        SocketAddr::V4(_) => Socket::new(Domain::IPV4, Type::STREAM, None)?,
+        SocketAddr::V6(_) => Socket::new(Domain::IPV6, Type::STREAM, None)?,
+    };
 
-  listener.set_nonblocking(true)?;
-  listener.set_nodelay(true)?;
-  listener.set_reuse_address(true)?;
-  listener.set_linger(Some(Duration::from_secs(0)))?;
-  listener.bind(&addr.into())?;
-  listener.listen(i32::MAX)?;
+    listener.set_nonblocking(true)?;
+    listener.set_nodelay(true)?;
+    listener.set_reuse_address(true)?;
+    listener.set_linger(Some(Duration::from_secs(0)))?;
+    listener.bind(&addr.into())?;
+    listener.listen(i32::MAX)?;
 
-  let listener = std::net::TcpListener::from(listener);
-  let listener = tokio::net::TcpListener::from_std(listener)?;
-  Ok(listener)
+    let listener = std::net::TcpListener::from(listener);
+    let listener = tokio::net::TcpListener::from_std(listener)?;
+    Ok(listener)
 }

--- a/lessons/205/rust-app/src/main.rs
+++ b/lessons/205/rust-app/src/main.rs
@@ -5,11 +5,12 @@ mod metrics;
 mod routes;
 mod state;
 
-use std::future::ready;
+use std::{future::ready, io, net::{SocketAddr, ToSocketAddrs}, time::Duration};
 
 use axum::{http::StatusCode, routing::get, Router};
 use metrics::setup_metrics_recorder;
 use routes::save_images;
+use socket2::{Domain, Socket, Type};
 
 use self::{config::Config, routes::devices, state::AppState};
 
@@ -54,16 +55,36 @@ async fn main() {
         .with_state(state);
 
     // Bind the server to the configured port.
-    let listener = match tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port)).await {
-        Ok(listener) => listener,
-        Err(err) => {
-            eprintln!("Failed to bind to port {}: {:?}", port, err);
-            return;
-        }
+    let listener = match create_listener(format!("0.0.0.0:{}", port)) {
+      Ok(listener) => listener,
+      Err(err) => {
+          eprintln!("Failed to bind to port {}: {:?}", port, err);
+          return;
+      }
     };
 
     // Start the server.
     if let Err(err) = axum::serve(listener, app).await {
         eprintln!("Failed to start server: {:?}", err);
     }
+}
+
+fn create_listener<A: ToSocketAddrs>(addr: A) -> io::Result<tokio::net::TcpListener> {
+  let mut addrs = addr.to_socket_addrs()?;
+  let addr = addrs.next().unwrap();
+  let listener = match &addr {
+    SocketAddr::V4(_) => Socket::new(Domain::IPV4, Type::STREAM, None)?,
+    SocketAddr::V6(_) => Socket::new(Domain::IPV6, Type::STREAM, None)?,
+  };
+
+  listener.set_nonblocking(true)?;
+  listener.set_nodelay(true)?;
+  listener.set_reuse_address(true)?;
+  listener.set_linger(Some(Duration::from_secs(0)))?;
+  listener.bind(&addr.into())?;
+  listener.listen(i32::MAX)?;
+
+  let listener = std::net::TcpListener::from(listener);
+  let listener = tokio::net::TcpListener::from_std(listener)?;
+  Ok(listener)
 }


### PR DESCRIPTION
The default `TcpListener` in Rust has a very conservative max socket count (lower than Go). Above that threshold, Rust will start dropping socket connections (even if the hardware has the capability to process more).

Depending on the number of concurrent connections configured in the stress testing tool, given you still had CPU and RAM left, it's possible that you simply hit the limit for socket connections and the Rust server started dropping new connections.

![image](https://github.com/user-attachments/assets/dd372d51-c44e-46e2-b9c8-e1e3b82c6517)

This PR increases the max socket count to the max amount possible which should let the Rust server dig a little deeper.