### PR TITLE
feat(205-go-app): use env variables to improve GC performance

### DIFF
--- a/lessons/205/deploy/go-app/deployment.yaml
+++ b/lessons/205/deploy/go-app/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         image: aputra/go-app-205:v4
         imagePullPolicy: Always
         env:
+        - name: GOGC
+          value: "300"
+        - name: GOMEMLIMIT
+          value: "200MiB"
         - name: AWS_ACCESS_KEY_ID
           value: admin
         - name: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Allow the Go Garbage collector to use more memory to decrease the rate of garbage collection. I basically set the collection threshold scaler (GOGC) to 3x its normal value and put an upper limit of 200MiB (GOMEMLIMIT) to ensure the computed value never breaks out of the 256MiB container.

For Reference: https://go.dev/doc/gc-guide

Running wrk against the `/api/devices` endpoint locally resulted in the following.

## wrk -d10 -t2 -c10:
```
GOGC=100 - 1044 GC Cycles
  857696 requests in 10.01s, 470.33MB read
GOGC=300 - 334 GC Cycles
  1150434 requests in 10.00s, 630.86MB read
```
34% more requests, 68% less GC cycles

## wrk -d30 -t12 -c400:
```
GOGC=100 - 1711 GC Cycles
  2766113 requests in 30.10s, 1.48GB read
GOGC=300 - 665 GC Cycles
	  3598185 requests in 30.09s, 1.93GB read
```
30% more requests, 61% less GC cycles

The in-use/active memory never exceeded 4-5 MiB after a collection, so the computed limits never got higher than 22 MiB (in the GOGC=300 case), meaning GOMEMLIMIT would not come into effect, but keeping it there allows for rare cases (or the slower endpoint) to use more memory without GOGC putting the limit outside the container bounds.