### PR TITLE
Go cleanups for tutorial 205

### DIFF
--- a/lessons/205/go-app/images.go
+++ b/lessons/205/go-app/images.go
@@ -45,12 +45,12 @@ func NewImage() *Image {
 }
 
 // Save inserts a newly generated image into the Postgres database.
-func (i *Image) save(dbpool *pgxpool.Pool, m *metrics) error {
+func (i *Image) save(ctx context.Context, dbpool *pgxpool.Pool, m *metrics) error {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
 
 	// Execute the query to create a new image record (pgx automatically prepares and caches statements by default).
-	_, err := dbpool.Exec(context.Background(), "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
+	_, err := dbpool.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("dbpool.Exec failed: %w", err)
 	}
@@ -62,7 +62,7 @@ func (i *Image) save(dbpool *pgxpool.Pool, m *metrics) error {
 }
 
 // upload uploads S3 image to the bicket.
-func upload(client *s3.Client, bucket string, key string, path string, m *metrics) error {
+func upload(ctx context.Context, client *s3.Client, bucket string, key string, path string, m *metrics) error {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
 
@@ -81,7 +81,7 @@ func upload(client *s3.Client, bucket string, key string, path string, m *metric
 	}
 
 	// Upload the file to the S3 bucket.
-	_, err = client.PutObject(context.TODO(), input)
+	_, err = client.PutObject(ctx, input)
 	if err != nil {
 		return fmt.Errorf("svc.PutObject failed: %w", err)
 	}

--- a/lessons/205/go-app/main.go
+++ b/lessons/205/go-app/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 
@@ -91,7 +92,7 @@ func main() {
 // getHealth returns the status of the application.
 func (ms *MyServer) getHealth(w http.ResponseWriter, req *http.Request) {
 	// Placeholder for the health check
-	w.Write([]byte("OK"))
+	io.WriteString(w, "OK")
 }
 
 // getDevices returns a list of connected devices.
@@ -109,7 +110,6 @@ func (ms *MyServer) getDevices(w http.ResponseWriter, req *http.Request) {
 
 // getImage downloads image from S3
 func (ms *MyServer) getImage(w http.ResponseWriter, req *http.Request) {
-
 	// Generate a new image.
 	image := NewImage()
 
@@ -118,8 +118,7 @@ func (ms *MyServer) getImage(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Printf("upload failed: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
-
+		io.WriteString(w, "internal error")
 	}
 
 	// Save the image metadata to db.
@@ -127,10 +126,10 @@ func (ms *MyServer) getImage(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Printf("save failed: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
+		io.WriteString(w, "internal error")
 	}
 
-	w.Write([]byte("Saved!"))
+	io.WriteString(w, "Saved!")
 }
 
 // s3Connect initializes the S3 session.

--- a/lessons/205/go-app/server_test.go
+++ b/lessons/205/go-app/server_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func getContext(tb testing.TB) context.Context {
+	tb.Helper()
+
+	ctx, done := context.WithCancel(context.Background())
+	tb.Cleanup(done)
+	return ctx
+}
+
+func setupServer(tb testing.TB, ctx context.Context) *httptest.Server {
+	tb.Helper()
+
+	ms := NewMyServer(ctx, &Config{}, prometheus.NewRegistry())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", ms.getHealth)
+	mux.HandleFunc("GET /api/devices", ms.getDevices)
+
+	srv := httptest.NewServer(mux)
+	tb.Cleanup(srv.Close)
+	srv.EnableHTTP2 = true
+
+	return srv
+}
+
+func TestHeathcheck(t *testing.T) {
+	srv := setupServer(t, getContext(t))
+
+	res, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("failed to get healthz: %v", err)
+	}
+
+	resBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("failed to read body: %v", err)
+	}
+
+	if got, want := string(resBytes), "OK"; got != want {
+		t.Errorf("bad healthz: got %q, want %q", got, want)
+	}
+}
+
+func TestDevices(t *testing.T) {
+	srv := setupServer(t, getContext(t))
+
+	res, err := http.Get(srv.URL + "/api/devices")
+	if err != nil {
+		t.Fatalf("failed to get /api/devices: %v", err)
+	}
+
+	cType := res.Header.Get("Content-Type")
+	if want := "application/json"; cType != want {
+		t.Errorf("bad content-type: got %q, want %q", cType, want)
+	}
+
+	resBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("failed to read body: %v", err)
+	}
+
+	want := `[` +
+		`{"uuid":"b0e42fe7-31a5-4894-a441-007e5256afea","mac":"5F-33-CC-1F-43-82","firmware":"2.1.6"},` +
+		`{"uuid":"0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7","mac":"EF-2B-C4-F5-D6-34","firmware":"2.1.5"},` +
+		`{"uuid":"b16d0b53-14f1-4c11-8e29-b9fcef167c26","mac":"62-46-13-B7-B3-A1","firmware":"3.0.0"},` +
+		`{"uuid":"51bb1937-e005-4327-a3bd-9f32dcf00db8","mac":"96-A8-DE-5B-77-14","firmware":"1.0.1"},` +
+		`{"uuid":"e0a1d085-dce5-48db-a794-35640113fa67","mac":"7E-3B-62-A6-09-12","firmware":"3.5.6"}` +
+		`]`
+
+	if got := string(resBytes); got != want {
+		t.Errorf("mismatch: got %q, want %q", got, want)
+	}
+}
+
+//go:generate go test -count 5 -bench . -benchmem -cpuprofile default.pgo
+
+func BenchmarkEndpoints(b *testing.B) {
+	ctx := getContext(b)
+	srv := setupServer(b, ctx)
+
+	client := &http.Client{}
+
+	endpoints := []string{"/healthz", "/api/devices"}
+
+	for _, endpoint := range endpoints {
+		b.Run(endpoint, func(b *testing.B) {
+			url := srv.URL + endpoint
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					res, err := client.Get(url)
+					if err != nil {
+						b.Fatalf("failed to get %s: %v", endpoint, err)
+					}
+					res.Body.Close()
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Laying a little groundwork to make the code a bit easier to work with. The actual performance impact (of the changes that have any) is minimal and lost in the noise caused by allocations, the GC, and network traffic.

## Main changes

 * Using io.WriteString to clean up writing strings (esp. string constants)
 * Better use of contexts:
   * Piping them through to allow re-use
   * Creating appropriate contexts for init-time and per-request
 * Modularizing the parts of server initialization to ease testing of base behaviour
 * Adding tests and benchmarks for the "easy stuff"
 * Create a runtime profile from the benchmarks to use with PGO


## A note on PGO

PGO (Profile Guided Optimization) is now available, but not enabled by default. This was for a few reasons:
 1. This changeset is about cleanups not performance.
 2. The benefits are easy to lose in the noise, especially while other things (e.g. allocations, garbage collection, networking) have a more noticable impact.
 3. A more representative profile (i.e. from a real server) would be better than generating one from synthetic benchmarks.

I'll include a change to enable it by default if requested, or should I find a case where it makes a noticable difference (e.g. after some allocations are optimized away).

PGO can improve optimisations in a few ways:
 - functions/methods that are called a lot are given a higher inlining threshold allowing for deeper inlining
 - interface types can be "devirtualized" should the profile show that a given implementation of an interface is commonly used at a callsite.
 - Both of the above allows for better escape analysis, and flattens the call stack meaning the compiler is more likely to know it's safe to leave an object on the stack, and has more opportunities to do so, reducing allocations and GC work.

For more details: https://go.dev/doc/pgo

### Using PGO

There are 2 easy ways to build with PGO, as although there is a flag available to the compiler `-pgo <file>` to manually specify a profile to use, simply having a CPU profile in the file `default.pgo` in the directory of the main package will have it used as part of the build of that binary. If the profile contains data about other packages (e.g. the runtime, http server, Garbage collector, and 3rd party libraries) they will be rebuilt using the info from the profile too.

#### Create a profile

I created a task for `go generate` that runs the benchmarks and outputs the result as `default.pgo`. This file is automatically used if present, and will even apply automatically to the container builds because the `Dockerfile` copies the entire contents of the source directory. Updating this file with each code change is an option, as well as replacing it with a profile from a real server.

To use PGO, simply run `go generate` before building the server. To stop, delete the generated file (`default.pgo`). Be sure to run `go generate` after most code changes otherwise the profile will become stale.

#### Run `go generate` as part of building the container

This is a nice option as it ensures that you don't forget to update the profile every time the code changes. There are downsides:
 * It slows down the build by about 30s (likely not an issue)
 * It makes it harder / complicated to introduce a server-based profile because the `Dockerfile` will be generating one unconditionally
 * "Turning it off" to make comparisons require's updating the `Dockerfile` instead of simply `rm default.pgo`

To do this basically add this above the line to build the server:
```
RUN go generate
```