### PR TITLE
Tutorial 205 - Go memory use optimizations and PGO

### DIFF
--- a/lessons/205/go-app/Dockerfile
+++ b/lessons/205/go-app/Dockerfile
@@ -18,6 +18,8 @@ RUN go mod download && go mod verify
 
 COPY . .
 
+RUN go generate
+
 RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o server -a -ldflags="-s -w" -installsuffix cgo
 
 RUN upx --ultra-brute -qq server && upx -t server

--- a/lessons/205/go-app/main.go
+++ b/lessons/205/go-app/main.go
@@ -59,14 +59,13 @@ func StartPrometheusServer(c *Config, reg *prometheus.Registry) {
 	}()
 }
 
-func renderJSON(w http.ResponseWriter, s interface{}) {
-	b, err := json.Marshal(s)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+func renderJSON(w http.ResponseWriter, value any) {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(b)
+	if err := enc.Encode(value); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func main() {

--- a/lessons/205/go-app/main.go
+++ b/lessons/205/go-app/main.go
@@ -99,7 +99,7 @@ func (ms *MyServer) getHealth(w http.ResponseWriter, req *http.Request) {
 
 // getDevices returns a list of connected devices.
 func (ms *MyServer) getDevices(w http.ResponseWriter, req *http.Request) {
-	devices := []Device{
+	devices := [...]Device{
 		{UUID: "b0e42fe7-31a5-4894-a441-007e5256afea", Mac: "5F-33-CC-1F-43-82", Firmware: "2.1.6"},
 		{UUID: "0c3242f5-ae1f-4e0c-a31b-5ec93825b3e7", Mac: "EF-2B-C4-F5-D6-34", Firmware: "2.1.5"},
 		{UUID: "b16d0b53-14f1-4c11-8e29-b9fcef167c26", Mac: "62-46-13-B7-B3-A1", Firmware: "3.0.0"},
@@ -107,7 +107,7 @@ func (ms *MyServer) getDevices(w http.ResponseWriter, req *http.Request) {
 		{UUID: "e0a1d085-dce5-48db-a794-35640113fa67", Mac: "7E-3B-62-A6-09-12", Firmware: "3.5.6"},
 	}
 
-	renderJSON(w, devices)
+	renderJSON(w, &devices)
 }
 
 // getImage downloads image from S3

--- a/lessons/205/go-app/server_test.go
+++ b/lessons/205/go-app/server_test.go
@@ -76,7 +76,7 @@ func TestDevices(t *testing.T) {
 		`{"uuid":"b16d0b53-14f1-4c11-8e29-b9fcef167c26","mac":"62-46-13-B7-B3-A1","firmware":"3.0.0"},` +
 		`{"uuid":"51bb1937-e005-4327-a3bd-9f32dcf00db8","mac":"96-A8-DE-5B-77-14","firmware":"1.0.1"},` +
 		`{"uuid":"e0a1d085-dce5-48db-a794-35640113fa67","mac":"7E-3B-62-A6-09-12","firmware":"3.5.6"}` +
-		`]`
+		`]` + "\n"
 
 	if got := string(resBytes); got != want {
 		t.Errorf("mismatch: got %q, want %q", got, want)

--- a/lessons/205/go-app/server_test.go
+++ b/lessons/205/go-app/server_test.go
@@ -85,6 +85,8 @@ func TestDevices(t *testing.T) {
 
 //go:generate go test -count 5 -bench . -benchmem -cpuprofile default.pgo
 
+const benchmarkSize = 1000
+
 func BenchmarkEndToEnd(b *testing.B) {
 	ctx := getContext(b)
 	srv := setupServer(b, ctx)
@@ -96,15 +98,15 @@ func BenchmarkEndToEnd(b *testing.B) {
 	for _, endpoint := range endpoints {
 		b.Run(endpoint[1:], func(b *testing.B) {
 			url := srv.URL + endpoint
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
+			for range b.N {
+				for range benchmarkSize {
 					res, err := client.Get(url)
 					if err != nil {
 						b.Fatalf("failed to get %s: %v", endpoint, err)
 					}
 					res.Body.Close()
 				}
-			})
+			}
 		})
 	}
 }
@@ -121,12 +123,12 @@ func BenchmarkEndpoints(b *testing.B) {
 	for _, endpoint := range endpoints {
 		b.Run(endpoint[1:], func(b *testing.B) {
 			req := httptest.NewRequest("GET", endpoint, nil)
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
+			for range b.N {
+				for range benchmarkSize {
 					res := httptest.NewRecorder()
 					mux.ServeHTTP(res, req)
 				}
-			})
+			}
 		})
 	}
 }


### PR DESCRIPTION
A set of small changes (with long commit messages ;-) ) for increasing performance:

0. Improved the benchmarks added previously to be more useful (and less weird) by performing large fix-sized units of work on a single thread.
1. Removed a large source of garbage from JSON encoding (and made it simpler too!)
2. Used an array (instead of a slice) to hold devices, and passed it via pointer to JSON encoder
3. Enabled PGO support as it has some decent gains now that allocations are more under control

The benchmark improvements were the biggest textual change, while the others were only a few lines each.

The changes that manually improved the code did so to remove allocations, or shrink them overall, while PGO improved the final compiled code.

## Benchmarks:
```
                         │ bench-base.txt │           bench-json.txt             │           bench-array.txt            │            bench-pgo.txt             │
                         │     sec/op     │   sec/op     vs base                 │   sec/op     vs base                 │   sec/op     vs base                 │
EndToEnd/healthz-32           266.4m ± 2%   270.8m ± 3%       ~ (p=0.105 n=10)     267.1m ± 1%        ~ (p=0.631 n=10)    258.2m ± 1%   -3.09% (p=0.004 n=10)
EndToEnd/api/devices-32       271.2m ± 3%   278.6m ± 2%  +2.74% (p=0.004 n=10)     278.0m ± 1%   +2.50% (p=0.019 n=10)    268.8m ± 2%        ~ (p=0.280 n=10)
Endpoints/healthz-32          1.699m ± 3%   1.673m ± 3%       ~ (p=0.796 n=10)     1.682m ± 4%        ~ (p=0.912 n=10)    1.602m ± 5%   -5.69% (p=0.029 n=10)
Endpoints/api/devices-32      3.379m ± 2%   3.091m ± 2%  -8.53% (p=0.000 n=10)     3.029m ± 8%  -10.36% (p=0.000 n=10)    2.901m ± 4%  -14.16% (p=0.000 n=10)

                         │ bench-base.txt │            bench-json.txt            │           bench-array.txt            │            bench-pgo.txt             │
                         │      B/op      │     B/op      vs base                │     B/op      vs base                │     B/op      vs base                │
EndToEnd/healthz-32          16.75Mi ± 0%   16.74Mi ± 0%        ~ (p=0.971 n=10)   16.75Mi ± 0%        ~ (p=0.912 n=10)   16.74Mi ± 0%        ~ (p=0.436 n=10)
EndToEnd/api/devices-32      18.37Mi ± 0%   17.89Mi ± 0%   -2.61% (p=0.000 n=10)   17.88Mi ± 0%   -2.71% (p=0.000 n=10)   17.87Mi ± 0%   -2.73% (p=0.000 n=10)
Endpoints/healthz-32         992.2Ki ± 0%   992.2Ki ± 0%        ~ (p=0.419 n=10)   992.2Ki ± 0%        ~ (p=0.153 n=10)   992.2Ki ± 0%        ~ (p=0.570 n=10)
Endpoints/api/devices-32     2.072Mi ± 0%   1.613Mi ± 0%  -22.15% (p=0.000 n=10)   1.590Mi ± 0%  -23.26% (p=0.000 n=10)   1.590Mi ± 0%  -23.26% (p=0.000 n=10)

                         │ bench-base.txt │            bench-json.txt            │            bench-array.txt           │             bench-pgo.txt            │
                         │   allocs/op    │  allocs/op   vs base                 │  allocs/op   vs base                 │  allocs/op   vs base                 │
EndToEnd/healthz-32           121.7k ± 0%   121.7k ± 0%       ~ (p=0.469 n=10)     121.7k ± 0%        ~ (p=0.839 n=10)    120.7k ± 0%   -0.83% (p=0.000 n=10)
EndToEnd/api/devices-32       131.1k ± 0%   130.1k ± 0%  -0.78% (p=0.000 n=10)     129.1k ± 0%   -1.55% (p=0.000 n=10)    128.1k ± 0%   -2.32% (p=0.000 n=10)
Endpoints/healthz-32          10.00k ± 0%   10.00k ± 0%       ~ (p=1.000 n=10)     10.00k ± 0%        ~ (p=1.000 n=10)    10.00k ± 0%        ~ (p=1.000 n=10)  
Endpoints/api/devices-32      12.01k ± 0%   11.01k ± 0%  -8.35% (p=0.000 n=10)     10.01k ± 0%  -16.68% (p=0.000 n=10)    10.01k ± 0%  -16.68% (p=0.000 n=10)
```

These results use the new benchmarks, and show the changes at each step.

The E2E benchmarks aren't as useful as the endpoint ones, but do still trend in a good direction despite the noise. Those benchmarks are more for building the PGO profile anyway, as they actually perform HTTP requests/responses.

The endpoint tests are much clearer. Showing decent drops to allocation and CPU usage per 1000 requests. The healthcheck endpoint managed to score a 5-6% improvement in speed despite never being touched (all PGO). The devices endpoint now allocates 23% less memory and is 14% faster.

## WRK testing

### Light Load - wrk -d30s -t2 -c10
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
BEFORE:
    Latency   163.41us  129.71us   1.71ms   82.72%
    Req/Sec    33.76k     1.76k   40.56k    68.44%
  2022017 requests in 30.10s, 1.08GB read
AFTER:
    Latency   136.71us  112.59us   1.50ms   84.65%
    Req/Sec    41.01k     1.78k   46.43k    68.60%
  2455798 requests in 30.10s, 1.32GB read
```

### Heavy Load - wrk -d30s -t12 -c200
```
  Thread Stats   Avg      Stdev     Max   +/- Stdev
BEFORE:
    Latency     2.07ms    2.80ms  47.44ms   89.16%
    Req/Sec    23.79k     1.92k   41.22k    69.83%
  8524559 requests in 30.07s, 4.56GB read
AFTER:
    Latency     1.61ms    1.93ms  39.46ms   88.30%
    Req/Sec    26.24k     2.01k   35.30k    68.69%
  9402847 requests in 30.06s, 5.04GB read
```