### PR TITLE
Lesson 207 - add pure Zig implementation

### DIFF
--- a/lessons/207/1-test/3-zig-client.yaml
+++ b/lessons/207/1-test/3-zig-client.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zig-client
+  namespace: default
+data:
+  Tester.toml: |
+    [test]
+    url = "http://zig-app.api.svc.cluster.local:8080/api/devices"
+    parallelism = 1
+    num_threads = 301
+    stage_interval_s = 30
+    request_interval_ms = 20
+    request_timeout_ms = 200
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zig-client
+  namespace: default
+spec:
+  parallelism: 20
+  template:
+    metadata:
+      labels:
+        app: zig-client
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        # node: node-03
+        role: clients
+      containers:
+      - name: zig-client
+        image: aputra/load-tester-amd64:v10
+        ports:
+        - name: metrics
+          containerPort: 8080
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 1000m
+          limits:
+            memory: 512Mi
+            cpu: 1000m
+        volumeMounts:
+        - name: config
+          mountPath: Tester.toml
+          subPath: Tester.toml
+      volumes:
+      - name: config
+        configMap:
+          name: zig-client
+

--- a/lessons/207/README.md
+++ b/lessons/207/README.md
@@ -1,3 +1,3 @@
-# Zap (Zig) vs Actix (Rust): Performance Benchmark in Kubernetes
+# Zap (Zig) vs Actix (Rust) vs http.zig (Zig): Performance Benchmark in Kubernetes
 
 You can find tutorial [here](https://youtu.be/VxW0ijXAfOs).

--- a/lessons/207/deploy/zig-app/0-ns.yaml
+++ b/lessons/207/deploy/zig-app/0-ns.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: api

--- a/lessons/207/deploy/zig-app/1-deployment.yaml
+++ b/lessons/207/deploy/zig-app/1-deployment.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zig-app
+  namespace: api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: zig-app
+  template:
+    metadata:
+      labels:
+        app: zig-app
+    spec:
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      nodeSelector:
+        role: general
+        # node: node-01
+      containers:
+      - name: zig-app
+        image: aputra/zig-app-207:v6-2t-1w
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: "2"
+          limits:
+            memory: 256Mi
+            cpu: "2"
+        # readinessProbe:
+        #   httpGet:
+        #     path: /healthz
+        #     port: http
+        #   periodSeconds: 20
+        #   timeoutSeconds: 10
+        #   failureThreshold: 3
+        # livenessProbe:
+        #   httpGet:
+        #     path: /healthz
+        #     port: http
+        #   periodSeconds: 20
+        #   timeoutSeconds: 10
+        #   failureThreshold: 3
+

--- a/lessons/207/deploy/zig-app/2-service.yaml
+++ b/lessons/207/deploy/zig-app/2-service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zig-app
+  namespace: api
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  selector:
+    app: zig-app
+  type: ClusterIP

--- a/lessons/207/deploy/zig-app/3-client-pod-monitor.yaml
+++ b/lessons/207/deploy/zig-app/3-client-pod-monitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: zig-client
+  namespace: monitoring
+  labels:
+    prometheus: main
+spec:
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: zig-client
+  podMetricsEndpoints:
+  - port: metrics

--- a/lessons/207/http.zig/.dockerignore
+++ b/lessons/207/http.zig/.dockerignore
@@ -1,0 +1,2 @@
+.zig-cache
+zig-out

--- a/lessons/207/http.zig/Dockerfile
+++ b/lessons/207/http.zig/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:12.7 AS build
+
+ARG ZIG_VER=0.14.0-dev.1511+54b668f8a
+
+RUN apt-get update && apt-get install -y curl xz-utils
+
+RUN curl https://ziglang.org/builds/zig-linux-$(uname -m)-${ZIG_VER}.tar.xz -o zig-linux.tar.xz && \
+    tar xf zig-linux.tar.xz && \
+    mv zig-linux-$(uname -m)-${ZIG_VER}/ /opt/zig
+
+WORKDIR /app
+
+COPY . .
+
+# Using ReleaseSmall instead of ReleaseFast - because there is no CPU intensive work
+# in this app, so ReleaseSmall will give a smaller binary / better use of CPU cache
+RUN /opt/zig/zig build -Doptimize=ReleaseSmall -Dcpu=baseline
+
+FROM debian:12.6-slim
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY --from=build /app/zig-out/bin/http.zig /server
+
+CMD ["/server"]

--- a/lessons/207/http.zig/README.md
+++ b/lessons/207/http.zig/README.md
@@ -53,6 +53,19 @@ Requests/sec: 193313.51
 Transfer/sec:     22.86MB
 ```
 
+
+HTTP.zig in ReleaseFast mode
+```
+Running 30s test @ http://localhost:8086/api/devices
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   492.28us  185.23us   6.05ms   83.81%
+    Req/Sec    50.01k    11.59k   60.59k    79.05%
+  5985889 requests in 30.10s, 707.86MB read
+Requests/sec: 198855.02
+Transfer/sec:     23.52MB
+```
+
 ----
 
 Running both with Debug compiles, similar story
@@ -84,7 +97,7 @@ TL;DR - much of a muchness for runtime performance ! There really isnt anything 
 
 Actix generally has better latency, and less scatter (std deviation)
 
-Zig has a better peak throughput
+Zig has a better peak throughput, and uses 1 third the memory (at least with these config tweaks)
 
 -----
 

--- a/lessons/207/http.zig/README.md
+++ b/lessons/207/http.zig/README.md
@@ -53,14 +53,41 @@ Requests/sec: 193313.51
 Transfer/sec:     22.86MB
 ```
 
-TL;DR - much of a muchness !
+----
 
-There really isnt anything between them
+Running both with Debug compiles, similar story
+
+```
+Actix compiled in Debug mode
+
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     1.50ms  230.25us   5.05ms   86.76%
+    Req/Sec    16.73k     2.05k   67.69k    83.85%
+  1999217 requests in 30.10s, 310.78MB read
+Requests/sec:  66409.49
+Transfer/sec:     10.32MB
+```
+
+```
+Zig compiled in Debug mode
+
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency     0.88ms  281.05us  20.30ms   91.38%
+    Req/Sec    28.58k     2.83k   59.14k    87.60%
+  3418569 requests in 30.10s, 404.26MB read
+Requests/sec: 113569.44
+Transfer/sec:     13.43MB
+
+```
+
+TL;DR - much of a muchness for runtime performance ! There really isnt anything between them
 
 Actix generally has better latency, and less scatter (std deviation)
 
 Zig has a better peak throughput
 
-We are ONLY really measuring IO behaviour here though.
+-----
 
-I suspect things would stay about the same across the board as you add more CPU intensive endpoints
+The main difference (to me) is that the Actix build is pulling in a huge number of dependencies :( 
+
+The zig code is only pulling in 1 dependency

--- a/lessons/207/http.zig/README.md
+++ b/lessons/207/http.zig/README.md
@@ -1,0 +1,64 @@
+# Pure Zig port, using http.zig
+
+Note that there are some very app specific tweaks in the server config here, to tailor this server to the intended environment.
+
+This doesnt do much for performance, but its mainly to get the memory usage down
+
+## Comparison with Rust
+
+On a Mac M2, im seeing these figures on local
+
+testing with 
+
+- `wrk -c 100 -d 30 -t 4 http://localhost:8080/healthz`
+
+- `wrk -c 100 -d 30 -t 4 http://localhost:8080/api/devices`
+
+There is really no difference between the healthz endpoint and the api/devices endpoint that needs to JSONify a struct ... so really all the time
+is being spent doing IO
+
+
+-----
+
+Rust in --release mode
+
+```
+2.5 MB Binary
+6 MB Memory
+4 Threads
+
+Running 30s test @ http://localhost:8086/api/devices
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   440.79us  167.31us   4.09ms   83.65%
+    Req/Sec    46.01k     2.53k   51.07k    79.40%
+  5511737 requests in 30.10s, 856.79MB read
+Requests/sec: 183100.15
+Transfer/sec:     28.46MB
+```
+
+HTTP.zig in ReleaseSmall mode
+
+```
+141kb Binary
+2 MB Memory
+4 Threads
+
+Running 30s test @ http://localhost:8086/api/devices
+  4 threads and 100 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   507.73us  184.11us   4.19ms   85.25%
+    Req/Sec    48.57k    10.33k   57.82k    80.48%
+  5819106 requests in 30.10s, 688.14MB read
+Requests/sec: 193313.51
+Transfer/sec:     22.86MB
+```
+
+TL;DR - much of a muchness !
+
+Actix generally has better latency, and less scatter (std deviation)
+
+Zig has marginally better throughput
+
+We are ONLY really measuring IO behaviour here though.  Things would likely get different quickly once the app does anything more concrete
+

--- a/lessons/207/http.zig/README.md
+++ b/lessons/207/http.zig/README.md
@@ -14,8 +14,7 @@ testing with
 
 - `wrk -c 100 -d 30 -t 4 http://localhost:8080/api/devices`
 
-There is really no difference between the healthz endpoint and the api/devices endpoint that needs to JSONify a struct ... so really all the time
-is being spent doing IO
+There is really no difference between the healthz endpoint and the api/devices endpoint that needs to JSONify a struct ... so really all the time is being spent doing IO
 
 
 -----
@@ -56,9 +55,12 @@ Transfer/sec:     22.86MB
 
 TL;DR - much of a muchness !
 
+There really isnt anything between them
+
 Actix generally has better latency, and less scatter (std deviation)
 
-Zig has marginally better throughput
+Zig has a better peak throughput
 
-We are ONLY really measuring IO behaviour here though.  Things would likely get different quickly once the app does anything more concrete
+We are ONLY really measuring IO behaviour here though.
 
+I suspect things would stay about the same across the board as you add more CPU intensive endpoints

--- a/lessons/207/http.zig/build.zig
+++ b/lessons/207/http.zig/build.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "http.zig",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const httpz = b.dependency("httpz", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("httpz", httpz.module("httpz"));
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/lessons/207/http.zig/build.zig.zon
+++ b/lessons/207/http.zig/build.zig.zon
@@ -1,0 +1,39 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "http.zig",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        .httpz = .{
+            .url = "git+https://github.com/karlseguin/http.zig?ref=master#dadc4f72b7137380df1c54324ca4c0fa7d333767",
+            .hash = "12208fab56fa3082d207beb09b1d5134a447ce006e78026f6951d89dd8c1279bded5",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/lessons/207/http.zig/build.zig.zon
+++ b/lessons/207/http.zig/build.zig.zon
@@ -1,27 +1,6 @@
 .{
-    // This is the default name used by packages depending on this one. For
-    // example, when a user runs `zig fetch --save <url>`, this field is used
-    // as the key in the `dependencies` table. Although the user can choose a
-    // different name, most users will stick with this provided value.
-    //
-    // It is redundant to include "zig" in this name because it is already
-    // within the Zig package namespace.
     .name = "http.zig",
-
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.0",
-
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    //.minimum_zig_version = "0.11.0",
-
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
     .dependencies = .{
         .httpz = .{
             .url = "git+https://github.com/karlseguin/http.zig?ref=master#dadc4f72b7137380df1c54324ca4c0fa7d333767",
@@ -32,8 +11,5 @@
         "build.zig",
         "build.zig.zon",
         "src",
-        // For example...
-        //"LICENSE",
-        //"README.md",
     },
 }

--- a/lessons/207/http.zig/src/device.zig
+++ b/lessons/207/http.zig/src/device.zig
@@ -1,0 +1,7 @@
+// Device definition - placed in here so its re-usable across the app
+
+// Note that in Zig, imported files are just structs
+
+id: ?c_int = null,
+mac: ?[]const u8 = null,
+firmware: ?[]const u8 = null,

--- a/lessons/207/http.zig/src/main.zig
+++ b/lessons/207/http.zig/src/main.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+const port = 8086;
+
+const Device = struct {
+    id: ?c_int = null,
+    mac: ?[]const u8 = null,
+    firmware: ?[]const u8 = null,
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    var app = App{};
+
+    // playing around with fine tuning params to match what the prod system looks like
+    // with is 2 vCPUs ?
+    //
+    // This should consume around 2MB memory in total for sustained hits
+    var server = try httpz.Server(*App).init(allocator, .{
+        .address = "0.0.0.0",
+        .port = port,
+        .workers = .{
+            .large_buffer_count = 1,
+            .large_buffer_size = 1024,
+        },
+        .thread_pool = .{
+            .count = 1,
+            .buffer_size = 1024,
+        },
+        .request = .{
+            .buffer_size = 1024,
+            .max_header_count = 0,
+            .max_param_count = 0,
+            .max_query_count = 0,
+            .max_form_count = 0,
+            .max_multiform_count = 0,
+        },
+    }, &app);
+    var router = server.router(.{});
+    router.get("/healthz", App.healthz, .{});
+    router.get("/api/devices", App.getDevices, .{});
+
+    std.debug.print("http.zig listening on http://0.0.0.0:{d}\n", .{port});
+    try server.listen();
+}
+
+const App = struct {
+    fn healthz(_: *App, _: *httpz.Request, res: *httpz.Response) !void {
+        res.body = "OK";
+    }
+
+    fn getDevices(_: *App, _: *httpz.Request, res: *httpz.Response) !void {
+        try res.json([_]Device{Device{
+            .id = 1,
+            .mac = "EF-2B-C4-F5-D6-34",
+            .firmware = "2.1.5",
+        }}, .{});
+    }
+};

--- a/lessons/207/http.zig/src/main.zig
+++ b/lessons/207/http.zig/src/main.zig
@@ -1,13 +1,7 @@
 const std = @import("std");
 const httpz = @import("httpz");
 
-const port = 8086;
-
-const Device = struct {
-    id: ?c_int = null,
-    mac: ?[]const u8 = null,
-    firmware: ?[]const u8 = null,
-};
+const port = std.posix.getenv("PORT") orelse "8080";
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -46,6 +40,12 @@ pub fn main() !void {
     std.debug.print("http.zig listening on http://0.0.0.0:{d}\n", .{port});
     try server.listen();
 }
+
+const Device = struct {
+    id: ?c_int = null,
+    mac: ?[]const u8 = null,
+    firmware: ?[]const u8 = null,
+};
 
 const App = struct {
     fn healthz(_: *App, _: *httpz.Request, res: *httpz.Response) !void {

--- a/lessons/207/http.zig/src/main.zig
+++ b/lessons/207/http.zig/src/main.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 const httpz = @import("httpz");
+const Device = @import("device.zig");
 
-const port = std.posix.getenv("PORT") orelse "8080";
+const port = 8080;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -40,12 +41,6 @@ pub fn main() !void {
     std.debug.print("http.zig listening on http://0.0.0.0:{d}\n", .{port});
     try server.listen();
 }
-
-const Device = struct {
-    id: ?c_int = null,
-    mac: ?[]const u8 = null,
-    firmware: ?[]const u8 = null,
-};
 
 const App = struct {
     fn healthz(_: *App, _: *httpz.Request, res: *httpz.Response) !void {


### PR DESCRIPTION
Keeping the ZAP version intact, I have added a 3rd implementation here that does the same /healthz and /api/devices endpoints ... but using a pure zig lib instead

This creates an additional deployment 'zig-app' to go next to 'zap-app'. Hope that makes sense

This uses async IO (ie - old school worker pool of threads + non-blocking IO)

I have fine-tuned the server config in this case to reduce memory usage ... this should have no effect on performance, it's just to reduce runtime memory consumption.  You should in theory be able to run this in a pod with only 4 MB memory allocation !! 

Running this on local (Mac M2), im seeing around the same perf on Zig vs Rust.

Best Rust run is around 185k r/s on my machine
Best Zig run is around 198k r/s on my machine

Zig marginally better across the board, but more scatter in the results.  Much of a Muchness

A Rust expert could probably tune the Actix build to get closer to the Zig peak figure ?  

Memory usage and binary footprint significantly better than Rust 

Im not seeing any significant improvements in the Zap version by applying different tweaks. I am not familiar with Zap or facil so much

-----------

Later on, will followup with an extension to lesson 205, to do some Postgres and S3 (minio) updates inline with the Go version

Enjoy
