### PR TITLE
cache prepared stm

### DIFF
--- a/lessons/203/rust-app-v2/src/image.rs
+++ b/lessons/203/rust-app-v2/src/image.rs
@@ -74,7 +74,7 @@ impl Image {
         // Prepare the SQL query.
         let query = "INSERT INTO rust_image VALUES ($1, $2, $3)";
         let stmt = client
-            .prepare(query)
+            .prepare_cached(query)
             .await
             .context("failed to prepare query")?;
 


### PR DESCRIPTION
cache the prepared stmt on the client conn. gives much better performance (esp. in case of benching a single request).