### PR TITLE
Go parallel getImage handler, better errors, and fix DB

### DIFF
--- a/lessons/205/go-app/go.mod
+++ b/lessons/205/go-app/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/prometheus/client_golang v1.20.2
 	go.uber.org/automaxprocs v1.5.3
+	golang.org/x/sync v0.8.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -41,7 +42,6 @@ require (
 	github.com/prometheus/common v0.58.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/lessons/205/go-app/images.go
+++ b/lessons/205/go-app/images.go
@@ -45,31 +45,36 @@ func NewImage() *Image {
 }
 
 // Save inserts a newly generated image into the Postgres database.
-func (i *Image) save(ctx context.Context, tx pgx.Tx, m *metrics) error {
+func (i *Image) save(ctx context.Context, tx pgx.Tx, m *metrics) (err error) {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
+	defer func() {
+		if err == nil {
+			// Record the duration of the insert query.
+			m.duration.With(prometheus.Labels{"op": "db"}).Observe(time.Since(now).Seconds())
+		}
+	}()
 
 	// Execute the query to create a new image record (pgx automatically prepares and caches statements by default).
-	_, err := tx.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
-	if err != nil {
-		return fmt.Errorf("dbpool.Exec failed: %w", err)
-	}
-
-	// Record the duration of the insert query.
-	m.duration.With(prometheus.Labels{"op": "db"}).Observe(time.Since(now).Seconds())
-
-	return nil
+	_, err = tx.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
+	return annotate(err, "dbpool.Exec failed")
 }
 
 // upload uploads S3 image to the bicket.
-func upload(ctx context.Context, client *s3.Client, bucket string, key string, path string, m *metrics) error {
+func upload(ctx context.Context, client *s3.Client, bucket string, key string, path string, m *metrics) (err error) {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
+	defer func() {
+		if err == nil {
+			// Record the duration of the request to S3.
+			m.duration.With(prometheus.Labels{"op": "s3"}).Observe(time.Since(now).Seconds())
+		}
+	}()
 
 	// Read the file from the local file system.
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("os.Open failed, path %s: %w", path, err)
+		return annotate(err, "os.Open failed, path %s", path)
 	}
 	defer file.Close()
 
@@ -82,12 +87,5 @@ func upload(ctx context.Context, client *s3.Client, bucket string, key string, p
 
 	// Upload the file to the S3 bucket.
 	_, err = client.PutObject(ctx, input)
-	if err != nil {
-		return fmt.Errorf("svc.PutObject failed: %w", err)
-	}
-
-	// Record the duration of the request to S3.
-	m.duration.With(prometheus.Labels{"op": "s3"}).Observe(time.Since(now).Seconds())
-
-	return nil
+	return annotate(err, "client.PutObject failed")
 }

--- a/lessons/205/go-app/images.go
+++ b/lessons/205/go-app/images.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -45,12 +45,12 @@ func NewImage() *Image {
 }
 
 // Save inserts a newly generated image into the Postgres database.
-func (i *Image) save(ctx context.Context, dbpool *pgxpool.Pool, m *metrics) error {
+func (i *Image) save(ctx context.Context, tx pgx.Tx, m *metrics) error {
 	// Get the current time to record the duration of the request.
 	now := time.Now()
 
 	// Execute the query to create a new image record (pgx automatically prepares and caches statements by default).
-	_, err := dbpool.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
+	_, err := tx.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("dbpool.Exec failed: %w", err)
 	}

--- a/lessons/205/go-app/images.go
+++ b/lessons/205/go-app/images.go
@@ -56,7 +56,7 @@ func (i *Image) save(ctx context.Context, tx pgx.Tx, m *metrics) (err error) {
 	}()
 
 	// Execute the query to create a new image record (pgx automatically prepares and caches statements by default).
-	_, err = tx.Exec(ctx, "INSERT INTO `go_image` VALUES ($1, $2, $3)", i.ImageUUID, i.Key, i.CreatedAt)
+	_, err = tx.Exec(ctx, `INSERT INTO "go_image" VALUES ($1, $2, $3)`, i.ImageUUID, i.Key, i.CreatedAt)
 	return annotate(err, "dbpool.Exec failed")
 }
 


### PR DESCRIPTION
To match what Rust did in #258 (making save-image parallel) do something similar for Go. Also, insert a transaction such that the DB will never be updated unless the S3 upload succeeds by having a DB transaction wrap the whole process.

Fixed up error code with a helper to clean-up some returns, as well as standardize wrapping errors.

Finally, fix a bug that broke the DB submit code in PR #256 when it used the wrong quoting style for postgres databases. Although I am having trouble configuring Minio properly to do a full test, I was able to see this failure and test that my change worked (when S3 errors were ignored).