### PR TITLE
pgx defaults to 4 max connections or the number of CPUs available.

### DIFF
--- a/lessons/209/go-app/config.go
+++ b/lessons/209/go-app/config.go
@@ -63,6 +63,9 @@ type DbConfig struct {
 
 	// Database to store images.
 	Database string `yaml:"database"`
+
+	// Max connections to the database.
+	MaxConnections int `yaml:"maxConnections"`
 }
 
 // loadConfig loads app config from YAML file.

--- a/lessons/209/go-app/config.yaml
+++ b/lessons/209/go-app/config.yaml
@@ -12,3 +12,4 @@ db:
   password: devops123
   host: "192.168.50.221"
   database: mydb
+  maxConnections: 20

--- a/lessons/209/go-app/main.go
+++ b/lessons/209/go-app/main.go
@@ -164,8 +164,8 @@ func (ms *MyServer) s3Connect(ctx context.Context) {
 
 // dbConnect creates a connection pool to connect to Postgres.
 func (ms *MyServer) dbConnect(ctx context.Context) {
-	url := fmt.Sprintf("postgres://%s:%s@%s:5432/%s",
-		ms.config.DbConfig.User, ms.config.DbConfig.Password, ms.config.DbConfig.Host, ms.config.DbConfig.Database)
+	url := fmt.Sprintf("postgres://%s:%s@%s:5432/%s?pool_max_conns=%d",
+		ms.config.DbConfig.User, ms.config.DbConfig.Password, ms.config.DbConfig.Host, ms.config.DbConfig.Database, ms.config.DbConfig.MaxConnections)
 
 	// Connect to the Postgres database.
 	dbpool, err := pgxpool.New(ctx, url)


### PR DESCRIPTION
https://github.com/jackc/pgx/blob/v5.7.1/pgxpool/pool.go\#L298-L324 shows an example on how to increase max connections