### PR TITLE
Lesson 213: tune go app

### DIFF
--- a/lessons/213/go-app/Dockerfile
+++ b/lessons/213/go-app/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN go generate
 
-RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o server -a -ldflags="-s -w" -installsuffix cgo
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux GOAMD64=v2 go build -trimpath -tags osusergo,netgo -o server -a -ldflags="-s -w -buildid=" -gcflags="all=-m=0 -l=2 -dwarf=false" -installsuffix cgo
 
 FROM scratch
 


### PR DESCRIPTION
_Ensure fully static binary see https://www.dimoulis.net/posts/static-compilation-of-go-programs/
certain standard Go libraries use C bindings to provide extra functionality: net os/user_

- add tags (_yes, this overlaps with CGO_ENABLED=0_)

_enable amd64.v2 cpu instructions (any x86-64-v2 cpu after 2008) per_ https://en.wikipedia.org/wiki/X86-64

```
Go 1.18 introduced [4 architectural levels](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels) for AMD64. Each level differs in the set of x86 instructions that the compiler can include in the generated binaries:

GOAMD64=v1 (default): The baseline. Exclusively generates instructions that all 64-bit x86 processors can execute.
GOAMD64=v2: all v1 instructions, plus CMPXCHG16B, LAHF, SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3.
GOAMD64=v3: all v2 instructions, plus AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE.
GOAMD64=v4: all v3 instructions, plus AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL.
```

_trimpath_

_empty buildid for reproducible builds_

_agressive inlining_

More info
- https://dave.cheney.net/high-performance-go-workshop/gopherchina-2019.html#compiler_flags_exercises

or
```
      # go tool compile -help
      # go tool compile -d help
      # go help build
      # go help buildconstraint
```