### PR TITLE
Tell golang about memory limit and allow it to manage the 2 cores itself

### DIFF
--- a/lessons/213/k8s/deploy/go-app/1-deployment.yaml
+++ b/lessons/213/k8s/deploy/go-app/1-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: go-app
   namespace: default
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -30,13 +30,17 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: requests.memory
         resources:
           requests:
-            memory: 128Mi
-            cpu: 500m
-          limits:
-            memory: 256Mi
+            memory: 480Mi
             cpu: 1000m
+          limits:
+            memory: 512Mi
+            cpu: 2000m
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Set GOMEMLIMIT to ca 95% of actual limit to allow for a bit of overhead by the system

Same as #299 but based on main