### PR TITLE
fix(prometheus-nginx-exporter): prevent exporter crash on incorrect log format

### DIFF
--- a/lessons/141/prometheus-nginx-exporter/cmd/exporter/main.go
+++ b/lessons/141/prometheus-nginx-exporter/cmd/exporter/main.go
@@ -113,6 +113,11 @@ func tailAccessLogFile(m *metrics, path string) {
 		match := exp.FindStringSubmatch(line.Text)
 		result := make(map[string]string)
 
+		if len(match) == 0 {
+			log.Printf("No match found for line: %s", line.Text)
+			continue
+		}
+
 		for i, name := range exp.SubexpNames() {
 			if i != 0 && name != "" {
 				result[name] = match[i]

--- a/lessons/144/prometheus-nginx-exporter/cmd/exporter/main.go
+++ b/lessons/144/prometheus-nginx-exporter/cmd/exporter/main.go
@@ -113,6 +113,11 @@ func tailAccessLogFile(m *metrics, path string) {
 		match := exp.FindStringSubmatch(line.Text)
 		result := make(map[string]string)
 
+		if len(match) == 0 {
+			log.Printf("No match found for line: %s", line.Text)
+			continue
+		}
+
 		for i, name := range exp.SubexpNames() {
 			if i != 0 && name != "" {
 				result[name] = match[i]


### PR DESCRIPTION
In case in access.log file there is a line that does not match the regex, the app won't panic

So before adding match to a result map, it will check if length does not equal to 0