### PR TITLE
perf: Rust improvements

### DIFF
--- a/lessons/215/actix-app/Dockerfile
+++ b/lessons/215/actix-app/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY . .
 
+ENV RUSTFLAGS="-Ctarget-cpu=native"
+
 RUN cargo build --release
 
 FROM debian:12.7-slim

--- a/lessons/215/actix-app/src/routes.rs
+++ b/lessons/215/actix-app/src/routes.rs
@@ -11,11 +11,11 @@ async fn health() -> HttpResponse {
 /// Returns a list of connected devices.
 #[get("/api/devices")]
 async fn devices() -> HttpResponse {
-    let device = Device {
+    const DEVICE: Device<'static> = Device {
         id: 1,
         mac: "EF-2B-C4-F5-D6-34",
         firmware: "2.1.5",
     };
 
-    HttpResponse::Ok().json(device)
+    HttpResponse::Ok().json(DEVICE)
 }


### PR DESCRIPTION
I added small changes to Rust code to make it little bit more 1:1 with Zig version.

Changes:
- Device variable is changed as const. It should now act similar to `comptime Device`.
- Added RUSTFLAGS='-Ctarget-cpu=native' environment variable to dockerfile. Unlike Zig's `-O ReleaseFast` flag, Rust compiler doesn't use wide CPU registers by default, you have to specify CPU target in general.

Example assembly comparisons, if anyone interested in;
Rust - https://godbolt.org/z/9aG61z1a8
Zig - https://godbolt.org/z/4nYTEEY1j

I also tested both versions with bombardier. Differences are limited, and I don't think it would change the benchmark results too much, but :: [it's something](https://i.kym-cdn.com/photos/images/original/000/114/139/tumblr_lgedv2Vtt21qf4x93o1_40020110725-22047-38imqt.jpg) ::

Current main HEAD:
```
Bombarding http://localhost:8080/api/devices for 1m0s using 200 connection(s)
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec    286812.28   13257.35  325394.30
  Latency      696.38us   359.38us   126.93ms
  Latency Distribution
     50%   680.00us
     75%   712.00us
     90%   777.00us
     95%     0.90ms
     99%     1.00ms
  HTTP codes:
    1xx - 0, 2xx - 17194108, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    63.95MB/s
```

PR version:
```
Bombarding http://localhost:8080/api/devices for 1m0s using 200 connection(s)
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec    292939.26   13736.39  349142.71
  Latency      681.52us   291.79us   115.37ms
  Latency Distribution
     50%   665.00us
     75%   695.00us
     90%   768.00us
     95%     0.89ms
     99%     0.99ms
  HTTP codes:
    1xx - 0, 2xx - 17567441, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    65.34MB/s
```
