### PR TITLE
chore: Enable io-uring feature in actix-web

### DIFF
--- a/lessons/215/actix-app/Cargo.toml
+++ b/lessons/215/actix-app/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.209", features = ["derive"] }
-actix-web = "4"
+actix-web = { version = "4" , features = ["experimental-io-uring"] }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Enable io-uring feature for performance comparison with Zig’s zzz server.
In my local environment, this change has resulted in slightly performance improvements, detailed as follows:

As-is:
```
Summary:
  Success rate:	100.00%
  Total:	60.0020 secs
  Slowest:	0.0389 secs
  Fastest:	0.0004 secs
  Average:	0.0026 secs
  Requests/sec:	19116.0369

  Total data:	57.97 MiB
  Size/request:	53 B
  Size/sec:	989.40 KiB

Response time histogram:
  0.000 [1]       |
  0.004 [1080517] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.008 [59925]   |■
  0.012 [5722]    |
  0.016 [483]     |
  0.020 [106]     |
  0.023 [83]      |
  0.027 [57]      |
  0.031 [10]      |
  0.035 [18]      |
  0.039 [76]      |

Response time distribution:
  10.00% in 0.0017 secs
  25.00% in 0.0020 secs
  50.00% in 0.0024 secs
  75.00% in 0.0030 secs
  90.00% in 0.0037 secs
  95.00% in 0.0044 secs
  99.00% in 0.0071 secs
  99.90% in 0.0109 secs
  99.99% in 0.0266 secs


Details (average, fastest, slowest):
  DNS+dialup:	0.0025 secs, 0.0018 secs, 0.0033 secs
  DNS-lookup:	0.0001 secs, 0.0000 secs, 0.0005 secs

Status code distribution:
  [200] 1146998 responses
```

To-be:
```
Summary:
  Success rate:	100.00%
  Total:	60.0025 secs
  Slowest:	0.0459 secs
  Fastest:	0.0004 secs
  Average:	0.0026 secs
  Requests/sec:	19248.5760

  Total data:	58.38 MiB
  Size/request:	53 B
  Size/sec:	996.26 KiB

Response time histogram:
  0.000 [1]       |
  0.005 [1121610] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.010 [30492]   |
  0.014 [2374]    |
  0.019 [294]     |
  0.023 [90]      |
  0.028 [12]      |
  0.032 [45]      |
  0.037 [4]       |
  0.041 [26]      |
  0.046 [9]       |

Response time distribution:
  10.00% in 0.0016 secs
  25.00% in 0.0020 secs
  50.00% in 0.0024 secs
  75.00% in 0.0029 secs
  90.00% in 0.0037 secs
  95.00% in 0.0043 secs
  99.00% in 0.0070 secs
  99.90% in 0.0110 secs
  99.99% in 0.0202 secs


Details (average, fastest, slowest):
  DNS+dialup:	0.0019 secs, 0.0013 secs, 0.0028 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0004 secs

Status code distribution:
  [200] 1154957 responses
```
