### PR TITLE
213-go: make sure to close io.ReadCloser on saveDevice()

### DIFF
--- a/lessons/213/go-app/main.go
+++ b/lessons/213/go-app/main.go
@@ -112,6 +112,7 @@ func (ms *MyServer) saveDevice(w http.ResponseWriter, req *http.Request) {
 
 	// Parse the device from the request.
 	decoder := json.NewDecoder(req.Body)
+	defer req.Body.Close()
 	var d Device
 	err := decoder.Decode(&d)
 	if err != nil {


### PR DESCRIPTION
I'm not sure if it makes any difference to the test, but `http.Request.Body` does have an `io.ReadCloser` interface, so we should be making sure to close it after use.