### PR TITLE
Remove slow query log from MySQL

### DIFF
--- a/lessons/216/50-server.cnf
+++ b/lessons/216/50-server.cnf
@@ -9,9 +9,6 @@ innodb_log_buffer_size = 32M
 innodb_max_dirty_pages_pct = 90
 tmp_table_size= 128M
 max_heap_table_size= 128M
-slow_query_log = 1
-slow_query_log_file = /var/log/mysql/slow.log
-long_query_time = 1
 
 [mysqld]
 max_connections = 300


### PR DESCRIPTION
Despite that [I did indeed have slow query log enabled](https://gitlab.melroy.org/-/snippets/92) (for performance insides). In your case during executing benchmarks, I believe it's fair to disable slow query log fully. 

Since you don't do that for PostgreSQL either.

