### PR TITLE
Improve Nginx config

### DIFF
--- a/lessons/219/nginx/nginx.conf
+++ b/lessons/219/nginx/nginx.conf
@@ -1,14 +1,61 @@
 user nginx;
 worker_processes auto;
+worker_cpu_affinity auto;
+# Change the default thread pool settings
+thread_pool default threads=2 max_queue=16384;
 
 error_log /var/log/nginx/error.log notice;
 pid /var/run/nginx.pid;
 
 events {
-    worker_connections 1024;
+    worker_connections 16384;
+
+    # Serve many clients each thread (Linux only)
+    use epoll;
+    
+    # Accept as many connections as possible
+    multi_accept on;
 }
 
 http {
+    # Copies data between one FD and other from within the kernel
+    # faster than read() + write()
+    sendfile on;
+
+    # Use the default thread pool for asynchronous file I/O
+    aio threads;
+
+    # Only use AIO is used for when larger than or equal to this size
+    directio 6m;
+
+    # Send headers in one piece, it is better than sending them one by one
+    tcp_nopush on;
+
+    # Don't buffer data sent, good for small data bursts in real time
+    tcp_nodelay on;
+
+    # Disable logging if a file can't be found
+    log_not_found off;
+
+    # Server will close connection after this time
+    keepalive_timeout 65;
+
+    # Max size of types hash tables (processing static sets of data. eg. server names, map directives or mime types)
+    types_hash_max_size 2048;
+
+    # Max allowed size of the client request body
+    client_max_body_size 250M;
+
+    # If the request body size is more than the buffer size, then the entire (or partial)
+    # request body is written into a temporary file
+    client_body_buffer_size 512k;
+
+    # Request timed out
+    client_body_timeout 300s;
+
+    # Allow the server to close connection on non responding client, this will free up memory
+    reset_timedout_connection on;
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
@@ -20,7 +67,43 @@ http {
 
     sendfile on;
     keepalive_timeout 60;
-    gzip on;
+    gzip            on;
+    gzip_disable    msie6;
+
+    gzip_vary       on;
+    gzip_comp_level 3;
+    gzip_min_length 256;
+    gzip_buffers    16 8k;
+    gzip_proxied    any;
+    gzip_types
+            text/css
+            text/plain
+            text/javascript
+            text/cache-manifest
+            text/vcard
+            text/vnd.rim.location.xloc
+            text/vtt
+            text/x-component
+            text/x-cross-domain-policy
+            application/javascript
+            application/json
+            application/x-javascript
+            application/ld+json
+            application/xml
+            application/xml+rss
+            application/xhtml+xml
+            application/x-font-ttf
+            application/x-font-opentype
+            application/vnd.ms-fontobject
+            application/manifest+json
+            application/rss+xml
+            application/atom_xml
+            application/vnd.geo+json
+            application/x-web-app-manifest+json
+            image/svg+xml
+            image/x-icon
+            image/bmp
+            font/opentype;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Me again 😆 .You are (again) using default configurations. Which is not good. 

I try to come-up with again a better Nginx configuration. I don't use Apache myself, but you most likely want to fine-tune that setup as well.

`m6a.xlarge` might be not large enough with only 2 cores to really stress the system.

For now I set the Nginx thread pool to use only 2 threads. However, if your test environment will have 4 or 8 cores, please increase the `threads` in the thread pool as well as max queue and `worker_connections`!

Last but not least, you're not running the latest Nginx version. Try to run nginx v1.27.2