### PR TITLE
Apache Performance Improvements  

### DIFF
--- a/lessons/219/apache/httpd-mpm.conf
+++ b/lessons/219/apache/httpd-mpm.conf
@@ -2,11 +2,26 @@
     PidFile "logs/httpd.pid"
 </IfModule>
 
+## Since testing on instance with 2vCPU, 
+## ThreadsPerChild increased to 64 (more aggressive for 2 vCPUs)
+## ServerLimit set to 8 (2 vCPUs * 4)
+## MaxRequestWorkers set to 512 (64 * 8)
+## MaxConnectionsPerChild set to 10000 as you suggested (helps prevent memory leaks while still allowing good performance)
 <IfModule mpm_event_module>
-    StartServers             3
-    MinSpareThreads         75
-    MaxSpareThreads        250
-    ThreadsPerChild         25
-    MaxRequestWorkers      400
-    MaxConnectionsPerChild   0
+    StartServers             4
+    MinSpareThreads        100
+    MaxSpareThreads        300
+    ThreadsPerChild         64
+    ServerLimit             8
+    MaxRequestWorkers      512
+    MaxConnectionsPerChild  10000
 </IfModule>
+
+# <IfModule mpm_event_module>
+#     StartServers             3
+#     MinSpareThreads         75
+#     MaxSpareThreads        250
+#     ThreadsPerChild         25
+#     MaxRequestWorkers      400
+#     MaxConnectionsPerChild   0
+# </IfModule>

--- a/lessons/219/apache/httpd.conf
+++ b/lessons/219/apache/httpd.conf
@@ -96,11 +96,46 @@ LogLevel warn
     RequestHeader unset Proxy early
 </IfModule>
 
+# <IfModule mime_module>
+#     TypesConfig conf/mime.types
+#     AddType application/x-compress .Z
+#     AddType application/x-gzip .gz .tgz
+# </IfModule>
+
+###  improve the gzip setting
 <IfModule mime_module>
-    TypesConfig conf/mime.types
-    AddType application/x-compress .Z
+    # Basic MIME type definitions
     AddType application/x-gzip .gz .tgz
+    AddEncoding gzip .gz
+    
+    # Define all the content types that should be compressed
+    AddType text/css .css
+    AddType text/plain .txt
+    AddType text/javascript .js
+    AddType text/cache-manifest .manifest
+    AddType text/vcard .vcf
+    AddType text/vtt .vtt
+    AddType text/x-component .htc
+    AddType text/x-cross-domain-policy .crossdomain
+    
+    AddType application/javascript .js
+    AddType application/json .json
+    AddType application/ld+json .jsonld
+    AddType application/xml .xml
+    AddType application/rss+xml .rss
+    AddType application/xhtml+xml .xhtml
+    AddType application/x-font-ttf .ttf
+    AddType application/x-font-opentype .otf
+    AddType application/vnd.ms-fontobject .eot
+    AddType application/manifest+json .webmanifest
+    
+    AddType image/svg+xml .svg
+    AddType image/x-icon .ico
+    AddType image/bmp .bmp
+    
+    AddType font/opentype .otf
 </IfModule>
+
 
 Include conf/my-website.conf
 

--- a/lessons/219/apache/my-website.conf
+++ b/lessons/219/apache/my-website.conf
@@ -31,9 +31,13 @@ Listen 443
     SSLCertificateKeyFile "/etc/ssl/private/apache-antonputra-pvt-key.pem"
 	
 	ProxyPass /api/devices balancer://myapp/api/devices
+   ### Always use it if the backend server performs any redirections, uses absolute URLs, or sets headers like Location or Content-Location
+   ### In summary, ProxyPassReverse ensures that the response headers from the backend are adjusted to match the public-facing proxy URL, maintaining seamless access for clients.
+    ProxyPassReverse /api/devices balancer://myapp/api/devices
 
 	<Proxy balancer://myapp>
 		BalancerMember http://myapp-apache-0.antonputra.pvt:8080
         BalancerMember http://myapp-apache-1.antonputra.pvt:8080
+        ProxySet lbmethod=byrequests
 	</Proxy>
 </VirtualHost>


### PR DESCRIPTION
# Apache Performance Improvements  

Hi Anton,  

In this PR, I’ve made the following changes to improve Apache performance:  

## httpd-mpm.conf  
- **`ThreadsPerChild`** increased to 64 (more aggressive for 2 vCPUs)  
- **`ServerLimit`** set to 8 (2 vCPUs * 4)  
- **`MaxRequestWorkers`** set to 512 (64 * 8)  
- **`MaxConnectionsPerChild`** set to 10,000, as you suggested (helps prevent memory leaks while maintaining good performance)  
- **`StartServers`** increased to 4 to handle initial load more efficiently  
- **`MinSpareThreads`** and **`MaxSpareThreads`** adjusted proportionally to manage load variations  

## httpd.conf  
- Added content type to optimize gzip settings  

## my-website.conf  
- Added **`ProxyPassReverse`** to ensure these URLs align with the client’s view of the application, avoiding confusion or access issues  
