### PR TITLE
Lesson 215: [golang] use json-iterator instead of encoding/json

### DIFF
--- a/lessons/215/go-app/go.mod
+++ b/lessons/215/go-app/go.mod
@@ -1,3 +1,10 @@
 module go-app
 
 go 1.23.2
+
+require github.com/json-iterator/go v1.1.12
+
+require (
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+)

--- a/lessons/215/go-app/go.sum
+++ b/lessons/215/go-app/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/lessons/215/go-app/main.go
+++ b/lessons/215/go-app/main.go
@@ -1,26 +1,30 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const port = 8080
+
+// json - jsoniter object
+var json = jsoniter.ConfigFastest
 
 // MyServer placeholder.
 type MyServer struct{}
 
 func renderJSON(w http.ResponseWriter, value any, status int) {
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := enc.Encode(value); err != nil {
+	content, err := json.Marshal(value)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+	w.WriteHeader(status)
+	w.Write(content)
 }
 
 func main() {
@@ -39,7 +43,7 @@ func main() {
 // getHealth returns the status of the application.
 func (ms *MyServer) getHealth(w http.ResponseWriter, req *http.Request) {
 	// Placeholder for the health check
-	io.WriteString(w, "OK")
+	w.Write([]byte("OK"))
 }
 
 // getDevices returns a list of connected devices.


### PR DESCRIPTION
Switch to json-iterator a high-performance 100% compatible drop-in replacement of "encoding/json".

![Benchmark](https://camo.githubusercontent.com/fd595e2368cca5005a4af1c1d1128467e5eb3c84a0d92a9c1896ca0ddf55b9d0/687474703a2f2f6a736f6e697465722e636f6d2f62656e63686d61726b732f676f2d62656e63686d61726b2e706e67)