### PR TITLE
Enable http keepalive for nginx upstream

### DIFF
--- a/lessons/219/nginx/my-website.conf
+++ b/lessons/219/nginx/my-website.conf
@@ -29,6 +29,7 @@ server {
 upstream myapp {
     server myapp-nginx-0.antonputra.pvt:8080;
     server myapp-nginx-1.antonputra.pvt:8080;
+    keepalive 64;
 }
 
 server {
@@ -41,5 +42,7 @@ server {
 
     location / {
         proxy_pass http://myapp/;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
     }
 }

--- a/lessons/221/nginx/my-website.conf
+++ b/lessons/221/nginx/my-website.conf
@@ -17,6 +17,7 @@ server {
 upstream myapp {
     server api-nginx-0.antonputra.pvt:8080;
     server api-nginx-1.antonputra.pvt:8080;
+    keepalive 64;
 }
 
 server {
@@ -29,6 +30,8 @@ server {
 
     location / {
         proxy_pass http://myapp/;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
Enabling HTTP keepalive for upstream connections in NGINX can significantly improve performance in a reverse proxy scenario by:

- **Reducing CPU load** on upstream servers, as fewer HTTP connections need to be established.
- **Improving request latency** by reusing connections, which also aids in handling high request volumes.
  
This change aligns NGINX's behavior with Caddy and Apache, both of which enable keepalive by default. For more details, see:

- [reverse_proxy (Caddyfile directive) — Caddy Documentation](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#keepalive)
- [Apache Module mod_proxy_http](https://httpd.apache.org/docs/2.4/mod/mod_proxy_http.html)

References:

- [NGINX blog: 10 Tips for 10x Application Performance](https://www.f5.com/company/blog/nginx/10-tips-for-10x-application-performance#web-server-tuning) (Tip 9 – Tune Your Web Server for Performance)
- [NGINX blog: HTTP Keepalive Connections and Web Performance](https://www.f5.com/company/blog/nginx/http-keepalives-and-web-performance)
- [NGINX docs: ngx_http_upstream_module](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive)
