### PR TITLE
Add Cache-Control headers for static content

### DIFF
--- a/lessons/221/nginx/my-website.conf
+++ b/lessons/221/nginx/my-website.conf
@@ -28,10 +28,24 @@ server {
     ssl_certificate /etc/ssl/certs/nginx-antonputra-pvt.pem;
     ssl_certificate_key /etc/ssl/private/nginx-antonputra-pvt-key.pem;
 
+    # Default cache-control header
+    add_header Cache-Control "private, max-age=14400";
+
     location / {
         proxy_pass http://myapp/;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Static assets
+    location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|tgz|gz|rar|bz2|doc|pdf|ptt|tar|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|svgz?|ttf|ttc|otf|eot|woff2?)$ {
+        expires    25d;
+        add_header Access-Control-Allow-Origin "*";
+        add_header Cache-Control "public, no-transform";
+        # Uncomment if you want to diable access log for static files
+        # access_log off;
     }
 }


### PR DESCRIPTION
When we are talking about static data in general (especially when serving a static site).  A lot can be optimized by introducing caches on the correct request paths for the client (browser) to cache content.

In this PR, I add `Cache-Control` headers for Nginx (for 25 days on static content). Assuming the application itself doesn't set any headers.  
On static files I normally also do not add access logs. So under Nginx I also add `access_log off;` for this static location/files (it's up to you to disable access log on static files).

Changes are:

- Generic `Cache-Control` header
- Add HTTP `Cache-Control` headers for static files (in this case only JS, CSS and images like jpg, svg, ico and some media files)..
- Forward the host and proto using `X-Forwared-Host` and `X-Forwared-Proto` headers, to i dentifiy the original host



---


The same caching setup for Apache2 it is something like this:

```

<FilesMatch "\.(?:css(\.map)?|js(\.map)?|jpe?g|png|tgz|gz|rar|bz2|doc|pdf|ptt|tar|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|svgz?|ttf|ttc|otf|eot|woff2?)$">
  Header set Cache-Control "max-age=2160000, public, no-transform"
  Header unset Last-Modified
  Header unset ETag
</FilesMatch>


```

And for Caddy it is something like this:

```
{
...

    @staticFiles {
        path_regexp \.(?:css(\.map)?|js(\.map)?|jpe?g|png|tgz|gz|rar|bz2|doc|pdf|ptt|tar|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|svgz?|ttf|ttc|otf|eot|woff2?)$
    }

    header @staticFiles {
        Cache-Control "max-age=2160000, public, no-transform"
    }
}
```

