### PR TITLE
Add pricing:GetProducts to the Karpenter

### DIFF
--- a/lessons/114/terraform/controller-trust-policy.json
+++ b/lessons/114/terraform/controller-trust-policy.json
@@ -31,6 +31,12 @@
             "Effect": "Allow",
             "Resource": "*",
             "Sid": "ConditionalEC2Termination"
+        },
+        {
+            "Action": "pricing:GetProducts",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Sid": "PricingAnalyst"
         }
     ],
     "Version": "2012-10-17"


### PR DESCRIPTION
Hi,

This PR aims to add an additional policy to the `controller-trust-policy.json` file in the Karpenter lesson. 

After successfully installing the Helm release, an error message from the Karpenter pod indicates that it is not authorized to perform the `pricing:GetProducts` action. As a result, Karpenter will use the pricing information from 2022.