### PR TITLE
Enable experimental fast proxy engine

### DIFF
--- a/lessons/224/traefik/traefik.yaml
+++ b/lessons/224/traefik/traefik.yaml
@@ -22,3 +22,6 @@ log:
 
 accessLog:
   filePath: "/var/log/traefik-access.log"
+
+experimental:
+  fastProxy: {}


### PR DESCRIPTION
Hi.
Traefik from v3.2 supports new experimental fast proxy engine. Claims to handle 50% more requests per second.
Would be interesting to benchmark.
https://traefik.io/blog/traefik-proxy-v3-2-a-munster-release/