### PR TITLE
Replace the unused GIN index with a BTREE index

### DIFF
--- a/lessons/227/README.md
+++ b/lessons/227/README.md
@@ -10,7 +10,7 @@ CREATE TABLE product (
     jdoc jsonb
 );
 
-CREATE INDEX product_inx ON product USING GIN (jdoc);
+CREATE INDEX idx__product__price ON product using BTREE(((jdoc -> 'price')::NUMERIC));
 
 INSERT INTO product(jdoc) VALUES ('{"name": "Shampoo", "price": 7.90, "stock": 100}');
 INSERT INTO product(jdoc) VALUES ('{"name": "Hairspray", "price": 11.50, "stock": 100}');

--- a/lessons/227/client/store.go
+++ b/lessons/227/client/store.go
@@ -34,7 +34,7 @@ func (p *product) create(pg *postgres, mg *mongodb, db string, m *metrics) (err 
 
 	if db == "pg" {
 		b, err := json.Marshal(p)
-		fail(err, "json.Marshal(p) filaed")
+		fail(err, "json.Marshal(p) failed")
 
 		err = pg.dbpool.QueryRow(pg.context, `INSERT INTO product(jdoc) VALUES ($1) RETURNING id`, b).Scan(&p.PostgresId)
 

--- a/lessons/227/migration/0-sql.yaml
+++ b/lessons/227/migration/0-sql.yaml
@@ -24,13 +24,13 @@ data:
 
     COMMIT;
 
-    VACUUM full;
-
     -- Create Tables
 
     CREATE TABLE product (
       id SERIAL PRIMARY KEY,
       jdoc jsonb
     );
-
-    CREATE INDEX product_inx ON product USING GIN (jdoc);
+    
+    CREATE INDEX idx__product__price ON product using BTREE(((jdoc -> 'price')::NUMERIC));
+    
+    VACUUM full;


### PR DESCRIPTION
Replace the unused GIN index with a BTREE index when searching by price, because the `->` operator is not accelerated by the GIN index.

Each index in PG supports only specific "operator classes" (see https://www.postgresql.org/docs/current/gin.html#GIN-BUILTIN-OPCLASSES) . When working with JSONB, GIN has two modes:
* `jsonb_ops` (default), which supports the `?`, `?|`, `?&``@>`, `@?`,`@@`,, etc operators
* `jsonb_path_ops`, which is smaller and faster, but supports only `@>`, `@?` and `@@`

Notice that none of those support `->`, which means that the GIN index will not be used when filtering by `jsonb -> 'price'`. The gin is great only for "contains" type of operations.

In order to fix that, I replace the GIN, which indexes the whole JSON body, with a BTREE, which indexes only the property we are interested in. This should improve insterts/updates/deletes, as the index is smaller  and faster to create/update. Also it will speed-up searches, because now the query will use the index to filter by price.