### PR TITLE
Reduce postgresql IOPS and configure it to handle writes like mongodb

### DIFF
--- a/lessons/227/migration/0-sql.yaml
+++ b/lessons/227/migration/0-sql.yaml
@@ -7,6 +7,13 @@ metadata:
 data:
   init.sql: |
     --
+    -- Mongodb buffers writes to journal every 100ms by default.
+    -- Set postgresql to do the same. 
+    --
+    ALTER SYSTEM SET synchronous_commit=OFF;
+    ALTER SYSTEM SET wal_writer_delay='100ms';
+
+    --
     -- Create application users.
     --
     CREATE USER myapp WITH PASSWORD 'devops123' SUPERUSER CREATEDB CREATEROLE LOGIN;


### PR DESCRIPTION
MongoDB buffers writes in RAM and flushes them to disk every 100ms by default, [see journaling](https://www.mongodb.com/docs/manual/core/journaling/#journaling-process). 

Postgresql by default uses [synchronous_commit=on](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT) which means every request will be acknowledged only after it is written to write ahead log (WAL).

This PR aims to make the benchmark more accurate by configuring postgresql to act like mongodb by setting:

- [synchronous_commit](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT): OFF
- [wal_writer_delay](https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-WAL-WRITER-DELAY): 100ms