### PR TITLE
Make benchmarks with Elixir fairer

### DIFF
--- a/lessons/230/elixir-app/config/runtime.exs
+++ b/lessons/230/elixir-app/config/runtime.exs
@@ -14,6 +14,7 @@ if config_env() == :prod do
     # ssl: true,
     url: database_url,
     pool_size: String.to_integer(System.get_env("REPO_POOL_SIZE", "10")),
+    pool_count: String.to_integer(System.get_env("REPO_POOL_COUNT", "1")),
     queue_target: String.to_integer(System.get_env("REPO_QUEUE_TARGET", "50")),
     queue_interval: String.to_integer(System.get_env("REPO_QUEUE_INTERVAL", "1000")),
     socket_options: maybe_ipv6

--- a/lessons/230/elixir-app/lib/app/device.ex
+++ b/lessons/230/elixir-app/lib/app/device.ex
@@ -12,6 +12,6 @@ defmodule App.Device do
         [uuid, mac, firmware, created_at, updated_at]
       )
 
-    id
+    %{device | id: id}
   end
 end

--- a/lessons/230/elixir-app/lib/app/device.ex
+++ b/lessons/230/elixir-app/lib/app/device.ex
@@ -1,12 +1,17 @@
 defmodule App.Device do
-  use Ecto.Schema
-
   @derive {Jason.Encoder, only: [:id, :uuid, :mac, :firmware, :created_at, :updated_at]}
-  schema "devices" do
-    field(:uuid, :string)
-    field(:mac, :string)
-    field(:firmware, :string)
-    field(:created_at, :utc_datetime_usec)
-    field(:updated_at, :utc_datetime_usec)
+  defstruct [:id, :uuid, :mac, :firmware, :created_at, :updated_at]
+
+  def save(device) do
+    %{uuid: uuid, mac: mac, firmware: firmware, created_at: created_at, updated_at: updated_at} =
+      device
+
+    %{rows: [[id]]} =
+      App.Repo.query!(
+        "INSERT INTO \"devices\" (uuid, mac, firmware, created_at, updated_at) VALUES ($1, $2, $3, $4, $5) RETURNING id",
+        [uuid, mac, firmware, created_at, updated_at]
+      )
+
+    id
   end
 end

--- a/lessons/230/elixir-app/lib/app/router.ex
+++ b/lessons/230/elixir-app/lib/app/router.ex
@@ -10,22 +10,16 @@ defmodule App.Router do
       |> Peep.get_all_metrics()
       |> Peep.Prometheus.export()
 
-    conn
-    |> put_resp_content_type("text/plain")
-    |> send_resp(200, metrics)
-    |> halt()
+    text(conn, 200, metrics)
   end
 
   get "/healthz" do
-    conn
-    |> put_resp_content_type("text/plain")
-    |> send_resp(200, "OK")
-    |> halt()
+    text(conn, 200, "OK")
   end
 
   get "/api/devices" do
     devices = [
-      %{
+      %App.Device{
         id: 1,
         uuid: "9add349c-c35c-4d32-ab0f-53da1ba40a2a",
         mac: "5F-33-CC-1F-43-82",
@@ -33,7 +27,7 @@ defmodule App.Router do
         created_at: "2024-05-28T15:21:51.137Z",
         updated_at: "2024-05-28T15:21:51.137Z"
       },
-      %{
+      %App.Device{
         id: 2,
         uuid: "d2293412-36eb-46e7-9231-af7e9249fffe",
         mac: "E7-34-96-33-0C-4C",
@@ -41,7 +35,7 @@ defmodule App.Router do
         created_at: "2024-01-28T15:20:51.137Z",
         updated_at: "2024-01-28T15:20:51.137Z"
       },
-      %{
+      %App.Device{
         id: 3,
         uuid: "eee58ca8-ca51-47a5-ab48-163fd0e44b77",
         mac: "68-93-9B-B5-33-B9",
@@ -51,20 +45,17 @@ defmodule App.Router do
       }
     ]
 
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(200, Jason.encode!(devices))
-    |> halt()
+    json(conn, 200, devices)
   end
 
   post "/api/devices" do
     try do
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       body = Jason.decode!(body)
-      now = DateTime.utc_now()
+      now = DateTime.utc_now() |> DateTime.to_string()
 
       device =
-        App.Repo.insert!(%App.Device{
+        App.Device.save(%App.Device{
           uuid: Ecto.UUID.generate(),
           mac: body["mac"],
           firmware: body["firmware"],
@@ -72,23 +63,28 @@ defmodule App.Router do
           updated_at: now
         })
 
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(201, Jason.encode!(device))
-      |> halt()
+      json(conn, 201, device)
     rescue
       e ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(400, Jason.encode!(%{message: Exception.message(e)}))
-        |> halt()
+        json(conn, 400, %{message: Exception.message(e)})
     end
   end
 
   match _ do
+    text(conn, 404, "Not found")
+  end
+
+  defp text(conn, status, body) do
     conn
     |> put_resp_content_type("text/plain")
-    |> send_resp(404, "Not found")
+    |> send_resp(status, body)
+    |> halt()
+  end
+
+  defp json(conn, status, payload) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, Jason.encode_to_iodata!(payload))
     |> halt()
   end
 end

--- a/lessons/230/elixir-app/priv/repo/migrations/20241108023931_create_devices.exs
+++ b/lessons/230/elixir-app/priv/repo/migrations/20241108023931_create_devices.exs
@@ -2,13 +2,12 @@ defmodule App.Repo.Migrations.CreateDevices do
   use Ecto.Migration
 
   def change do
-    create table(:devices, primary_key: false) do
-      add(:id, :bigserial, primary_key: true)
+    create table(:devices) do
       add(:uuid, :string)
       add(:mac, :string)
       add(:firmware, :string)
-      add(:created_at, :timestamptz, null: false)
-      add(:updated_at, :timestamptz, null: false)
+      add(:created_at, :string, null: false)
+      add(:updated_at, :string, null: false)
     end
   end
 end


### PR DESCRIPTION
* The code previously used `Jason.encode!` but `Jason.encode_to_iodata!` should be preferred over IO devices. This should increase performance and reduce memory usage. This is what frameworks such as a Phoenix would have used by default

* The code was not encoding `App.Device` structs in the first test, but regular maps/dictionaries, which meant it could not preallocate the key data (an optimization I am certain the Go runtime performs)

* Ensure the datetime is encoded once in second test. The Go test was also encoding once, but the Elixir one did it four times (twice when encoding to JSON, twice when writing to the database)

* Bypass Ecto (a relational mapper) and use a direct query when inserting records. That's exactly what the Go benchmark does, which should make a large impact

* Allow :pool_count to be configured. If you are going to have a large pool size, the pool itself may become the bottleneck. If you want to have 500 connections on a machine with 8 cores, I recommend splitting them up, for example pool_size=64 * pool_count=8

I also refactored the code in the routes.ex to reduce duplication.