### PR TITLE
Use asyncpg in Python (231)

### DIFF
--- a/lessons/231/deploy/python-app/0-deployment.yaml
+++ b/lessons/231/deploy/python-app/0-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: MEMCACHED_HOST
           value: "memcache.antonputra.pvt"
         - name: POSTGRES_URI
-          value: "postgresql+psycopg://python_app:devops123@postgres.antonputra.pvt/mydb"
+          value: "postgresql+asyncpg://python_app:devops123@postgres.antonputra.pvt/mydb"
         - name: POSTGRES_POOL_SIZE
           value: "500"
         resources:

--- a/lessons/231/python-app/db.py
+++ b/lessons/231/python-app/db.py
@@ -2,19 +2,20 @@ import os
 
 from typing import Annotated
 from fastapi import Depends
-from sqlmodel import Session, create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 
-POSTGRES_URI = os.environ['POSTGRES_URI']
-POSTGRES_POOL_SIZE = int(os.environ['POSTGRES_POOL_SIZE'])
+POSTGRES_URI = os.environ["POSTGRES_URI"]
+POSTGRES_POOL_SIZE = int(os.environ["POSTGRES_POOL_SIZE"])
 
 
-engine = create_engine(POSTGRES_URI, pool_size=POSTGRES_POOL_SIZE)
+engine = create_async_engine(POSTGRES_URI, pool_size=POSTGRES_POOL_SIZE)
 
 
-def get_postgres_session():
-    with Session(engine) as session:
+async def get_postgres_session():
+    async with AsyncSession(engine) as session:
         yield session
 
 
-PostgresDep = Annotated[Session, Depends(get_postgres_session)]
+PostgresDep = Annotated[AsyncSession, Depends(get_postgres_session)]

--- a/lessons/231/python-app/main.py
+++ b/lessons/231/python-app/main.py
@@ -14,7 +14,7 @@ from pymemcache.client.base import Client
 
 app = FastAPI()
 
-MEMCACHED_HOST = os.environ['MEMCACHED_HOST']
+MEMCACHED_HOST = os.environ["MEMCACHED_HOST"]
 cache_client = Client(MEMCACHED_HOST)
 
 metrics_app = make_asgi_app()
@@ -67,7 +67,7 @@ async def get_devices():
             "firmware": "4.3.1",
             "created_at": "2024-08-28T15:18:21.137Z",
             "updated_at": "2024-08-28T15:18:21.137Z",
-        }
+        },
     ]
 
     return devices
@@ -84,7 +84,7 @@ async def create_device(device: Device, session: PostgresDep) -> Device:
     # Measure the same insert operation as in Go
     start_time = time.time()
     session.add(device)
-    session.commit()
+    await session.commit()
     H.labels(op="insert", db="postgres").observe(time.time() - start_time)
 
     # Measure the same set operation as in Go
@@ -93,6 +93,6 @@ async def create_device(device: Device, session: PostgresDep) -> Device:
     H.labels(op="set", db="memcache").observe(time.time() - start_time)
 
     # Refresh the device to return it to the client.
-    session.refresh(device)
+    await session.refresh(device)
 
     return device

--- a/lessons/231/python-app/requirements.txt
+++ b/lessons/231/python-app/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.7.0
 anyio==4.7.0
+asyncpg==0.30.0
 certifi==2024.8.30
 click==8.1.7
 dnspython==2.7.0


### PR DESCRIPTION
This should make Python be able to leverage concurrency, at least regarding postgres. I did not change anything related to memcached.

I am currently on vacation and about to leave at this moment, so I won't be able to test things. (E.g., I am not 100% sure if the URI with asyncpg is that one.) Please tell if you face any problems with the PR, I will likely be able to read later today.

---

Quick explanation on the problem of the previous version:

By marking a route as `async` as was done with `create_device`, it will be run in the main thread, blocking other things when running non-async functions. Since your db driver is not async, every db call will block any other ones that might be incoming. This greatly prevents concurrency. It might be possible that even just dropping the async determination of the route would increase performance, as that would run routes in a threadpool instead of the event loop in the main thread.

However, once we use an async db driver, not only the problem above goes away, but we should be leveraging concurrency greatly. Of course, Python will still have a (likely huge) inferior performance, but now in a scenario where the concurrency model makes more sense at least.