### PR TITLE
Use ORJSONResponse for static data in Python (231)

### DIFF
--- a/lessons/231/python-app/main.py
+++ b/lessons/231/python-app/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from fastapi import FastAPI
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, ORJSONResponse
 from models import Device
 from db import PostgresDep
 from metrics import H
@@ -41,7 +41,7 @@ async def health():
     return "OK"
 
 
-@app.get("/api/devices")
+@app.get("/api/devices", response_class=ORJSONResponse)
 async def get_devices():
     devices = [
         {
@@ -70,7 +70,7 @@ async def get_devices():
         },
     ]
 
-    return devices
+    return ORJSONResponse(devices)
 
 
 @app.post("/api/devices", status_code=201)

--- a/lessons/231/python-app/requirements.txt
+++ b/lessons/231/python-app/requirements.txt
@@ -16,6 +16,7 @@ Jinja2==3.1.4
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+orjson==3.10.12
 prometheus-fastapi-instrumentator==7.0.0
 prometheus_client==0.21.1
 psycopg==3.2.3


### PR DESCRIPTION
Using an `ORJSONResponse` uses the [`orjson`](https://github.com/ijl/orjson) serializer and also bypass the whole `json_encoder` validation process. This is explained in the [FastAPI documentation](https://fastapi.tiangolo.com/advanced/custom-response/#use-orjsonresponse):

> For example, if you are squeezing performance, you can install and use [orjson](https://github.com/ijl/orjson) and set the response to be ORJSONResponse.
>
> Import the Response class (sub-class) you want to use and declare it in the path operation decorator.
>
> For large responses, returning a Response directly is much faster than returning a dictionary.
>
> This is because by default, FastAPI will inspect every item inside and make sure it is serializable as JSON, using the same [JSON Compatible Encoder](https://fastapi.tiangolo.com/tutorial/encoder/) explained in the tutorial. This is what allows you to return arbitrary objects, for example database models.
>
> But if you are certain that the content that you are returning is serializable with JSON, you can pass it directly to the response class and avoid the extra overhead that FastAPI would have by passing your return content through the jsonable_encoder before passing it to the response class.