### PR TITLE
Use Python's `perf_counter` for benchmarking purposes.

### DIFF
--- a/lessons/231/python-app/main.py
+++ b/lessons/231/python-app/main.py
@@ -94,15 +94,15 @@ async def create_device(device: Device, session: PostgresDep) -> Device:
     )
 
     # Measure the same insert operation as in Go
-    start_time = time.time()
+    start_time = time.perf_counter()
     device_result = await session.execute(stmt)
     device_dict = device_result.mappings().one()
     await session.commit()
-    H.labels(op="insert", db="postgres").observe(time.time() - start_time)
+    H.labels(op="insert", db="postgres").observe(time.perf_counter() - start_time)
 
     # Measure the same set operation as in Go
-    start_time = time.time()
+    start_time = time.perf_counter()
     cache_client.set(str(device_uuid), dict(device_dict), expire=20)
-    H.labels(op="set", db="memcache").observe(time.time() - start_time)
+    H.labels(op="set", db="memcache").observe(time.perf_counter() - start_time)
 
     return device_dict


### PR DESCRIPTION
This PR replaces all uses of `time.time()` with `time.perf_counter()`. This is because the `time.time()` function uses the system clock, meaning it is susceptible to things such as leap seconds and clock re-syncs, which may impact the results. `perf_counter` uses the same unit (seconds).

Realistically, this is unlikely to happen during testing and this change does not affect performance (tested myself), but it makes the results more reproducible.