### PR TITLE
Change list to tuple, add limiting for max threads

### DIFF
--- a/lessons/231/python-app/Dockerfile
+++ b/lessons/231/python-app/Dockerfile
@@ -24,4 +24,4 @@ COPY . /app
 # CMD ["fastapi", "run", "--workers", "2", "main.py"]
 
 # 4 for the second test to achieve full CPU utilization
-CMD ["fastapi", "run", "--workers", "4", "main.py"]
+CMD ["uvicorn", "--workers", "4", "--no-access-log", "main:app"]

--- a/lessons/231/python-app/Dockerfile
+++ b/lessons/231/python-app/Dockerfile
@@ -24,4 +24,4 @@ COPY . /app
 # CMD ["fastapi", "run", "--workers", "2", "main.py"]
 
 # 4 for the second test to achieve full CPU utilization
-CMD ["uvicorn", "--workers", "4", "--no-access-log", "main:app"]
+CMD ["uvicorn", "--workers", "4", "--no-access-log", "--backlog", "0", "main:app"]


### PR DESCRIPTION
Hello Anton, in this PR:
- Change response to tuple instead of list:
  - Doing this allows for faster read of the object as tuples are faster than lists
- Add limiting for max threads that can be used by the app;
- Add usage of uvicorn with `--no-access-log` option;
- Remove uvicorn backlog number of connections;

You can adjust this
```
limitter.total_tokens = 1000
```
to a lower or higher number depending on the machine you use.