### PR TITLE
fix: remove unnecessary logging filter

### DIFF
--- a/lessons/231/python-app/main.py
+++ b/lessons/231/python-app/main.py
@@ -20,20 +20,6 @@ app = FastAPI(lifespan=lifespan)
 metrics_app = make_asgi_app()
 app.mount("/metrics", metrics_app)
 
-# Disable access logs to match Go implementation
-block_endpoints = ["/api/devices", "/metrics/", "/metrics"]
-
-
-class LogFilter(logging.Filter):
-    def filter(self, record):
-        if record.args and len(record.args) >= 3:
-            if record.args[2] in block_endpoints:
-                return False
-        return True
-
-
-uvicorn_logger = logging.getLogger("uvicorn.access")
-uvicorn_logger.addFilter(LogFilter())
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Since the code now uses `--log-level error`, we no longer need an additional logger filter. Access-level logs are not captured anyway, and using a custom filter can slightly slow down the code.
Sorry for late response for previous PR.