### PR TITLE
Improve fastapi perfs

### DIFF
--- a/lessons/232/python-app/main.py
+++ b/lessons/232/python-app/main.py
@@ -25,12 +25,12 @@ logger.setLevel(logging.DEBUG)
 
 
 @app.get("/healthz", response_class=PlainTextResponse)
-def health():
+async def health():
     return PlainTextResponse("OK")
 
 
 @app.get("/api/devices", response_class=ORJSONResponse)
-def get_devices():
+async def get_devices():
     devices = (
         {
             "id": 1,

--- a/lessons/232/python-app/main.py
+++ b/lessons/232/python-app/main.py
@@ -26,7 +26,7 @@ logger.setLevel(logging.DEBUG)
 
 @app.get("/healthz", response_class=PlainTextResponse)
 def health():
-    return "OK"
+    return PlainTextResponse("OK")
 
 
 @app.get("/api/devices", response_class=ORJSONResponse)
@@ -58,7 +58,7 @@ def get_devices():
         },
     )
 
-    return devices
+    return ORJSONResponse(devices)
 
 
 class DeviceRequest(BaseModel):
@@ -113,7 +113,7 @@ async def create_device(
 
         H.labels(op="set", db="memcache").observe(time.perf_counter() - start_time)
 
-        return device_dict
+        return ORJSONResponse(device_dict)
 
     except PostgresError:
         logger.exception("Postgres error")
@@ -142,14 +142,14 @@ async def get_device_stats(cache_client: MemcachedDep):
         stats = await cache_client.stats()
         # H.labels(op="stats", db="memcache").observe(time.perf_counter() - start_time)
 
-        return {
+        return ORJSONResponse({
             "curr_items": stats.get(b"curr_items", 0),
             "total_items": stats.get(b"total_items", 0),
             "bytes": stats.get(b"bytes", 0),
             "curr_connections": stats.get(b"curr_connections", 0),
             "get_hits": stats.get(b"get_hits", 0),
             "get_misses": stats.get(b"get_misses", 0),
-        }
+        })
     except aiomcache.exceptions.ClientException:
         logger.exception("Memcached error")
         raise HTTPException(


### PR DESCRIPTION
- return Response objects to avoid extra overhead (https://fastapi.tiangolo.com/advanced/custom-response/#use-orjsonresponse)

> For large responses, returning a Response directly is much faster than returning a dictionary.

> This is because by default, FastAPI will inspect every item inside and make sure it is serializable as JSON, using the same [JSON Compatible Encoder](https://fastapi.tiangolo.com/tutorial/encoder/) explained in the tutorial. This is what allows you to return arbitrary objects, for example database models.

> But if you are certain that the content that you are returning is serializable with JSON, you can pass it directly to the response class and avoid the extra overhead that FastAPI would have by passing your return content through the jsonable_encoder before passing it to the response class.

- declare routes as async (https://fastapi.tiangolo.com/async/#in-a-hurry)

> If your application (somehow) doesn't have to communicate with anything else and wait for it to respond, use async def.

- call `orjson.dumps` one time only