### PR TITLE
Update vm.args.eex

### DIFF
--- a/lessons/233/elixir-app/rel/vm.args.eex
+++ b/lessons/233/elixir-app/rel/vm.args.eex
@@ -8,3 +8,5 @@
 ##-env ERL_FULLSWEEP_AFTER 10
 
 +sbwt none
+# Enable SMP automatically based on availability
+-smp auto


### PR DESCRIPTION
Enable SMP automatically based on availability.
This is first thing which guides recommend to do.
Also keep in mind that BEAM works better with concurrent model, which is mean that some sort of CPU suites better than others, for example last benches show that AMD CPUs works much more effectively with multicore utilisation and Intels better for single core performance. Moreover, BEAM usually runs without Kubernetes or Docker if performance really is must have. Overall Kubernetes written on Go and much more suites to Go than to Elixir, also add some latency and mostly solve same issues which solved in BEAM decades ago.