### PR TITLE
Elixir disable busywait for dirty and io schedulers

### DIFF
--- a/lessons/233/elixir-app/rel/vm.args.eex
+++ b/lessons/233/elixir-app/rel/vm.args.eex
@@ -8,5 +8,8 @@
 ##-env ERL_FULLSWEEP_AFTER 10
 
 +sbwt none
++sbwtdcpu none
++sbwtdio none
+
 # Enable SMP automatically based on availability
 -smp auto


### PR DESCRIPTION
Disables busy waiting in Elixir for: 

 * dirty cpu scheduler
 * io
 
These changes might help reduce the CPU throttling which is what is really killing the benchmark imo. Obviously Go outpaces Elixir but it should be a lot closer than what I'm seeing in your runs.
 
Also in the last video I thought I heard you say you allocated the entire VM but I'm still seeing `limits.cpu: "2000m"` in the deployment.yaml. A m7a.large only has 2 cores so why enforce any sort of throttling for a programming language benchmark?

https://home.robusta.dev/blog/stop-using-cpu-limits

`Pods will be throttled if they exceed their limit. If limit is unspecified, then the pods can use excess CPU when available.`

https://adoptingerlang.org/docs/production/kubernetes/

> The CPU limit of 2000m, which we think of as meaning 2 CPU cores, does not actually restrict the process to 2 cores. If 8 schedulers are being used and there are the same number of cores on the node, those 8 will still spread across all the cores and run in parallel. But the quota is still 200000 and more likely to be exceeded when 8 schedulers are taking time on 8 cores. Even without the busy wait, a scheduler must do work of its own and can be unnecessary overhead when trying to stay within some CPU usage constraints.

If we're limiting the CPU limit to 2000m, we should only be running 2 schedulers anyway, but because of the overhead we might want to set it to `+S 1` (one scheduler) in order to keep it from hitting the cpu threshold. That might actually result in a better result for this benchmark where hitting the threshold seems to cause havoc with the runtime.

Anyway hope this helps.
  