### PR TITLE
Replace fastapi with robyn for raw performance

### DIFF
--- a/lessons/236/fastapi-app/Dockerfile
+++ b/lessons/236/fastapi-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.1-slim-bookworm AS build
+FROM python:3.12.1-slim-bookworm AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -9,15 +9,16 @@ RUN pip install --upgrade pip
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-FROM python:3.13.1-slim-bookworm
+FROM python:3.12.1-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-COPY --from=build /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=build /usr/local/bin /usr/local/bin
 
 COPY . /app
 
-CMD ["gunicorn", "-w", "2", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "60", "--graceful-timeout", "60",  "--log-level", "error", "main:app",  "--bind", "0.0.0.0:8080"]
+# CMD ["gunicorn", "-w", "2", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "60", "--graceful-timeout", "60",  "--log-level", "error", "main:app",  "--bind", "0.0.0.0:8080"]
+CMD ["python3", "main.py", "--processes", "2"]

--- a/lessons/236/fastapi-app/requirements.txt
+++ b/lessons/236/fastapi-app/requirements.txt
@@ -19,7 +19,7 @@ Jinja2==3.1.5
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
-orjson==3.10.13
+orjson==3.9.15
 packaging==24.2
 prometheus-fastapi-instrumentator==7.0.0
 prometheus_client==0.21.1
@@ -41,6 +41,7 @@ starlette==0.41.3
 typer==0.15.1
 typing_extensions==4.12.2
 uvicorn==0.34.0
-uvloop==0.21.0
+uvloop==0.19.0
 watchfiles==1.0.3
 websockets==14.1
+robyn==0.65.0


### PR DESCRIPTION
I know it is not what the test is about but when in comes to raw performance I haven't seen better framework than Robyn. It is a relatively new framework that has Rust core, so this will benefit the tests. Also it is marvelous and very similar to fastapi in terms of syntax.

IMO main "issue" with FastAPI and other python frameworks is that we are sacrificing raw performance for ease of use and rapid development. 

So in this PR:
- lowered the python version because 3.13 is not supported yet in robyn
- adapted the endpoints to use robyn
- adapted responses to robyn syntax 

If you are good with this change I will continue to push here so all database and memcached is working as expected.