### PR TITLE
Improve both apps for 244

### DIFF
--- a/lessons/244/go-app/cmd/gnet/server.go
+++ b/lessons/244/go-app/cmd/gnet/server.go
@@ -90,7 +90,7 @@ func (hc *httpCodec) parse(data []byte) (int, []byte, error) {
 }
 
 func (hc *httpCodec) getContentLength() int {
-	if hc.contentLength != -1 {
+	if hc.contentLength > 0 {
 		return hc.contentLength
 	}
 

--- a/lessons/244/rust-app/Cargo.lock
+++ b/lessons/244/rust-app/Cargo.lock
@@ -110,28 +110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bb8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
-dependencies = [
- "futures-util",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
-name = "bb8-postgres"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e570e6557cd0f88d28d32afa76644873271a70dc22656df565b2021c4036aa9c"
-dependencies = [
- "bb8",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +165,40 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.15",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -287,6 +299,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
@@ -302,6 +327,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hmac"
@@ -461,9 +492,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -477,6 +508,16 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -636,7 +677,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
  "zerocopy 0.8.17",
 ]
 
@@ -654,8 +695,7 @@ name = "rust-app"
 version = "0.1.0"
 dependencies = [
  "axum",
- "bb8",
- "bb8-postgres",
+ "deadpool-postgres",
  "serde",
  "tokio",
  "tokio-postgres",
@@ -943,7 +983,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/lessons/244/rust-app/Cargo.toml
+++ b/lessons/244/rust-app/Cargo.toml
@@ -7,13 +7,9 @@ edition = "2021"
 axum = "0.8.1"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-bb8 = "0.9.0"
-bb8-postgres = "0.9.0"
-tokio-postgres = "0.7.2"
+tokio-postgres = "0.7.13"
+deadpool-postgres = "0.14.1"
 
 [profile.release]
-debug = false
-lto = "fat"
+lto = "thin"
 codegen-units = 1
-split-debuginfo = "off"
-panic = "abort"

--- a/lessons/244/rust-app/src/routes.rs
+++ b/lessons/244/rust-app/src/routes.rs
@@ -44,7 +44,7 @@ pub async fn get_devices() -> impl IntoResponse {
         },
     ];
 
-    (StatusCode::OK, axum::Json(devices))
+    (StatusCode::OK, Json(devices))
 }
 
 pub async fn create_device(

--- a/lessons/244/rust-app/src/routes.rs
+++ b/lessons/244/rust-app/src/routes.rs
@@ -3,11 +3,7 @@ use axum::{http::StatusCode, response::IntoResponse};
 use crate::device::Device;
 
 use axum::{extract::State, Json};
-use bb8::Pool;
-use bb8_postgres::PostgresConnectionManager;
-use tokio_postgres::NoTls;
-
-type ConnectionPool = Pool<PostgresConnectionManager<NoTls>>;
+use deadpool_postgres::Pool;
 
 // (Placeholder) Returns the status of the application.
 pub async fn health() -> impl IntoResponse {
@@ -48,7 +44,7 @@ pub async fn get_devices() -> impl IntoResponse {
 }
 
 pub async fn create_device(
-    State(pool): State<ConnectionPool>,
+    State(pool): State<Pool>,
     Json(device): Json<Device>,
 ) -> Result<Json<Device>, (StatusCode, String)> {
     let conn = pool.get().await.map_err(internal_error)?;

--- a/lessons/244/rust-app/src/routes.rs
+++ b/lessons/244/rust-app/src/routes.rs
@@ -49,11 +49,13 @@ pub async fn create_device(
 ) -> Result<Json<Device>, (StatusCode, String)> {
     let conn = pool.get().await.map_err(internal_error)?;
 
+    let stmt = conn
+        .prepare_cached("INSERT INTO rust_device (mac, firmware) VALUES ($1, $2) RETURNING id")
+        .await
+        .map_err(internal_error)?;
+
     let row = conn
-        .query_one(
-            "INSERT INTO rust_device (mac, firmware) VALUES ($1, $2) RETURNING id",
-            &[&device.mac, &device.firmware],
-        )
+        .query_one(&stmt, &[&device.mac, &device.firmware])
         .await
         .map_err(internal_error)?;
 


### PR DESCRIPTION
### Proposed changes

1. Fix the processing of the COntent-Length header for the golang app. Without his change, all requests from JMeter were failing

2. Use `deadpool` instead of `bb8` as connection pool

3. Use `prepare_cached()` + `query_one()` instead of just `query_one()` for a significant speedup


After those changes, the rust app was significantly outperforming the golang one, which for some reason failed to scale beyond 64 DB connections.

JMeter tests:

* 20, 100 and 500 concurrent requests
* 8, 16, 24, 32 and 64 DB connections
* the apps * jmeter were running on different machines to avoid interference 

<img width="1505" alt="c8" src="https://github.com/user-attachments/assets/a0c8964f-9913-48f4-8fa4-a63cd61c0fb3" />
<img width="1505" alt="C16" src="https://github.com/user-attachments/assets/49ff2aee-a6d1-4f48-b524-e272d95fbb58" />
<img width="1505" alt="C24" src="https://github.com/user-attachments/assets/7410799e-472a-4256-85c9-83d2c5afea9b" />
<img width="1505" alt="C32" src="https://github.com/user-attachments/assets/85ba032a-9781-413c-bbfc-4984ea0f20e4" />
<img width="1505" alt="C64" src="https://github.com/user-attachments/assets/916fc11f-67c2-41bc-8fe6-7ac9df253e3a" />
