### PR TITLE
249 TCP vs UDP: optimize

### DIFF
--- a/lessons/249/app/monitoring.cpp
+++ b/lessons/249/app/monitoring.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <chrono>
 #include "monitoring.hpp"
 #include <string>
@@ -16,30 +17,18 @@ long long monitoring::get_time()
 // Parse the timestamp from the payload.
 long long monitoring::parse_time(char buf[MAXDATASIZE])
 {
-    // Create an empty array to hold the timestamp.
-    char result[TIMESIZE];
-
-    // Iterate over the buffer and parse the timestamp.
-    for (int i = 0; i < TIMESIZE - 1; i++)
-    {
-        result[i] = buf[TIMESTART + i];
-    }
-
-    // Terminate the string with a NUL byte.
-    result[TIMESIZE - 1] = '\0';
-
     // Convert the string to a long long and return it to the client.
-    return std::stol(result);
+    return std::strtoll(buf + TIMESTART, NULL, 10);
 }
 
 // Generate a payload message with a timestamp to measure the duration.
-std::string monitoring::generate_payload()
+size_t monitoring::generate_payload(char buf[MAXDATASIZE])
 {
     // Take a timestamp and start measuring the time for processing a Trade event message.
     long long start = monitoring::get_time();
 
     // Prepare the message that we'll send over the wire.
-    return "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\":" + std::to_string(start) + "}";
+    return std::snprintf(buf, MAXDATASIZE, "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\":%lld}", start);
 }
 
 // Get interval buckets for Prometheus in nanoseconds.

--- a/lessons/249/app/monitoring.hpp
+++ b/lessons/249/app/monitoring.hpp
@@ -8,12 +8,16 @@
 #define MAXDATASIZE 90
 #define TIMESTART 69
 #define TIMESIZE 20
+// 1432 is usually a safe size over WAN, but certain networks may have lower limits and others may have higher limits.
+// If doing the test on localhost, this number can be increased to 63k (63 * 1024) which should greatly improve throughput.
+#define UDP_BUFSIZE 1432
+//#define UDP_BUFSIZE 63 * 1024
 
 namespace monitoring
 {
     long long get_time();
     long long parse_time(char buf[MAXDATASIZE]);
-    std::string generate_payload();
+    size_t generate_payload(char buf[MAXDATASIZE]);
     std::vector<double> get_buckets();
 }
 

--- a/lessons/249/app/tcp_server.cpp
+++ b/lessons/249/app/tcp_server.cpp
@@ -6,18 +6,18 @@
 #include "monitoring.hpp"
 
 using std::string;
-using std::to_string;
-using std::chrono::duration;
-using std::chrono::microseconds;
 using std::chrono::system_clock;
 
 // Port on the server to listen for incoming connections.
 #define PORT "8080"
 
+using namespace std::literals;
 // Declare some variables for the test.
 int stage_count = 1;
-int stage_interval_s = 1000;
-int sleep_us = 100000000;
+//auto stage_interval = 1000s;
+//auto sleep_time = 100000000us;
+auto stage_interval = 0s;
+auto sleep_time = 1us;
 
 // Number of pending connections the server will hold (queue size).
 #define BACKLOG 10
@@ -25,8 +25,7 @@ int sleep_us = 100000000;
 int main(void)
 {
     const char *enable_monitoring_env = std::getenv("ENABLE_MONITORING");
-
-    std::string enable_monitoring(enable_monitoring_env);
+    bool enable_monitoring = enable_monitoring_env && std::strcmp(enable_monitoring_env, "true") == 0;
 
     // These variables hold server and client file descriptors. We use them to read and write data.
     int server_fd, client_fd, bytes_sent;
@@ -50,12 +49,17 @@ int main(void)
     hints.ai_flags = AI_PASSIVE;
 
     // Fill out the struct. Assign the address of my localhost to the socket structure, etc.
-    getaddrinfo(NULL, PORT, &hints, &servinfo);
+    int err;
+    if ((err = getaddrinfo(NULL, PORT, &hints, &servinfo)) != 0)
+    {
+         std::cerr << "getaddrinfo failed: " << gai_strerror(err) << std::endl;
+         return 1;
+    }
 
     // Create a socket for the server and return a file descriptor that we can use to listen for new connections.
     server_fd = socket(servinfo->ai_family, servinfo->ai_socktype, servinfo->ai_protocol);
 
-    std::cout << "server's socket file descriptor is " + to_string(server_fd) << std::endl;
+    std::cout << "server's socket file descriptor is " << server_fd << std::endl;
 
     // Associate socket with a port on your local machine. Returns -1 on error.
     int bind_result = bind(server_fd, servinfo->ai_addr, servinfo->ai_addrlen);
@@ -64,7 +68,7 @@ int main(void)
     if (bind_result != 0)
     {
         perror("bind failed");
-        exit(1);
+        return 1;
     }
 
     // Start listening for incoming connections. Returns -1 on error.
@@ -74,7 +78,7 @@ int main(void)
     if (listen_result != 0)
     {
         perror("listen failed");
-        exit(1);
+        return 1;
     }
 
     // Get the size of the client IP address, IPv4 or IPv6.
@@ -86,12 +90,25 @@ int main(void)
     if (client_fd == -1)
     {
         perror("accept failed");
-        exit(1);
+        return 1;
     }
 
-    std::cout << "client's socket file descriptor is " + to_string(client_fd) << std::endl;
+    std::cout << "client's socket file descriptor is " << client_fd << std::endl;
 
     string msg = "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\": 170341283583666}";
+
+    // Batch messages together. This helps UDP more than TCP as the kernel will do this automatically
+    // for TCP unless TCP_NODELAY is set. TCP will still be helped by the reduced number
+    // of syscalls and context switches.
+    msg.reserve(UDP_BUFSIZE);
+    if (!enable_monitoring)
+    {
+        intptr_t batch_count = UDP_BUFSIZE / msg.length() - 1;
+        for(; batch_count > 0; --batch_count)
+        {
+            msg += "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\": 170341283583666}";
+        }
+    }
 
     for (int stage = 0; stage < stage_count; stage++)
     {
@@ -101,59 +118,72 @@ int main(void)
         // When the client establishes a connection, continuously send the same message over and over.
         while (true)
         {
-            if (enable_monitoring == "true")
+            if (enable_monitoring)
             {
                 // Generate a payload message with a timestamp to measure the duration.
-                msg = monitoring::generate_payload();
+                msg.clear();
+                while(msg.length() + MAXDATASIZE < UDP_BUFSIZE)
+                {
+                    char buf[MAXDATASIZE];
+                    monitoring::generate_payload(buf);
+                    msg += buf;
+                }
             }
 
             // Send data to the client.
-            bytes_sent = send(client_fd, msg.c_str(), msg.length(), 0);
+            bytes_sent = send(client_fd, msg.data(), msg.length(), 0);
 
             // Check if we successfully sent data to the client.
             if (bytes_sent == -1)
             {
-                std::cout << "failed to send a message to the client" << std::endl;
-                exit(1);
+                std::cerr << "failed to send a message to the client" << std::endl;
+                return 1;
             }
 
             // Get the current time.
-            duration<double> elapsed_seconds = system_clock::now() - start_time;
+            auto elapsed_time = system_clock::now() - start_time;
 
             // Finish the state based on the time elapsed.
-            if (elapsed_seconds.count() > stage_interval_s)
+            if (elapsed_time > stage_interval)
             {
-                sleep_us -= 1;
-                std::cout << to_string(stage) + " stage is finished, sleeping now for: " + to_string(sleep_us) + " microseconds" << std::endl;
+                sleep_time -= 1us;
+                std::cout << stage << " stage is finished, sleeping now for: " << sleep_time.count() << " microseconds" << std::endl;
                 break;
             }
 
             // Sleep to add a delay between sending messages to the client.
-            std::this_thread::sleep_for(microseconds(sleep_us));
+            std::this_thread::sleep_for(sleep_time);
         }
     }
 
     while (true)
     {
-        if (enable_monitoring == "true")
+        if (enable_monitoring)
         {
             // Generate a payload message with a timestamp to measure the duration.
-            msg = monitoring::generate_payload();
+            msg.clear();
+            while(msg.length() + MAXDATASIZE < UDP_BUFSIZE)
+            {
+              char buf[MAXDATASIZE];
+              monitoring::generate_payload(buf);
+              msg += buf;
+            }
         }
 
         // Send data to the client.
-        bytes_sent = send(client_fd, msg.c_str(), msg.length(), 0);
+        bytes_sent = send(client_fd, msg.data(), msg.length(), 0);
 
         // Check if we successfully sent data to the client.
         if (bytes_sent == -1)
         {
             perror("send failed");
-            exit(1);
+            return 1;
         }
     }
 
-    // Close the connection on your socket descriptor.
-    close(server_fd);
+    // graceful shutdown
+    shutdown(client_fd, SHUT_RDWR);
+    close(client_fd);
 
     return 0;
 }

--- a/lessons/249/app/udp_client.cpp
+++ b/lessons/249/app/udp_client.cpp
@@ -6,33 +6,28 @@
 #include "monitoring.hpp"
 
 using std::string;
-using std::to_string;
-using std::chrono::duration;
-using std::chrono::microseconds;
 using std::chrono::system_clock;
 
 #define PORT "8080"
-#define ADDRESS "udp-server.antonputra.pvt"
+//#define ADDRESS "udp-server.antonputra.pvt"
+#define ADDRESS "localhost"
 
+using namespace std::literals;
 // Declare some variables for the test.
 int stage_count = 1;
-int stage_interval_s = 0;
-int sleep_us = 1;
+auto stage_interval = 0s;
+auto sleep_time = 1us;
 
 int main()
 {
     const char *enable_monitoring_env = std::getenv("ENABLE_MONITORING");
-
-    std::string enable_monitoring(enable_monitoring_env);
+    bool enable_monitoring = enable_monitoring_env && std::strcmp(enable_monitoring_env, "true") == 0;
 
     // This variable hold file descriptor. We use them to read and write data.
     int client_fd, bytes_send;
 
     // addrinfo is used to prepare the socket address structures.
     struct addrinfo hints, *servinfo;
-
-    // This variable is used to hold the client IP address.
-    struct sockaddr_storage client_addr;
 
     // Make sure the struct is empty.
     memset(&hints, 0, sizeof hints);
@@ -47,12 +42,30 @@ int main()
     hints.ai_flags = AI_PASSIVE;
 
     // Fill out the struct. Assign the address of of the server to the socket structure, etc.
-    getaddrinfo(ADDRESS, PORT, &hints, &servinfo);
+    int err;
+    if ((err = getaddrinfo(NULL, PORT, &hints, &servinfo)) != 0)
+    {
+        std::cerr << "getaddrinfo failed: " << gai_strerror(err) << std::endl;
+        return 1;
+    }
 
     // Create a socket for the client and return a file descriptor that we can use to send data.
     client_fd = socket(servinfo->ai_family, servinfo->ai_socktype, servinfo->ai_protocol);
 
     string msg = "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\": 170341283583666}";
+
+    // Batch messages together. This helps UDP more than TCP as the kernel will do this automatically
+    // for TCP unless TCP_NODELAY is set. TCP will still be helped by the reduced number
+    // of syscalls and context switches.
+    msg.reserve(UDP_BUFSIZE);
+    if (!enable_monitoring)
+    {
+        intptr_t batch_count = UDP_BUFSIZE / msg.length() - 1;
+        for(; batch_count > 0; --batch_count)
+        {
+            msg += "{\"id\":66009,\"mac\":\"81-6E-79-DA-5A-B2\",\"firmware\":\"4.0.2\",\"create_at\": 170341283583666}";
+        }
+    }
 
     for (int stage = 0; stage < stage_count; stage++)
     {
@@ -63,32 +76,38 @@ int main()
         while (true)
         {
             // Sleep to add a delay between sending messages to the client.
-            std::this_thread::sleep_for(microseconds(sleep_us));
+            std::this_thread::sleep_for(sleep_time);
 
-            if (enable_monitoring == "true")
+            if (enable_monitoring)
             {
                 // Generate a payload message with a timestamp to measure the duration.
-                msg = monitoring::generate_payload();
+                msg.clear();
+                while(msg.length() + MAXDATASIZE < UDP_BUFSIZE)
+                {
+                    char buf[MAXDATASIZE];
+                    monitoring::generate_payload(buf);
+                    msg += buf;
+                }
             }
 
             // Send data to UDP server. Returns -1 on error.
-            bytes_send = sendto(client_fd, msg.c_str(), msg.length(), 0, servinfo->ai_addr, servinfo->ai_addrlen);
+            bytes_send = sendto(client_fd, msg.data(), msg.length(), 0, servinfo->ai_addr, servinfo->ai_addrlen);
 
             // Check if we successfully send data ro server.
             if (bytes_send == -1)
             {
-                std::cout << "failed to send a message to the server." << std::endl;
-                exit(1);
+                perror("failed to send a message to the server: ");
+                return 1;
             }
 
             // Get the current time.
-            duration<double> elapsed_seconds = system_clock::now() - start_time;
+            auto elapsed_time = system_clock::now() - start_time;
 
             // Finish the state based on the time elapsed.
-            if (elapsed_seconds.count() > stage_interval_s)
+            if (elapsed_time > stage_interval)
             {
-                sleep_us -= 1;
-                std::cout << to_string(stage) + " stage is finished, sleeping now for: " + to_string(sleep_us) + " microseconds" << std::endl;
+                sleep_time -= 1us;
+                std::cout << stage << " stage is finished, sleeping now for: " << sleep_time.count() << " microseconds" << std::endl;
                 break;
             }
         }
@@ -98,10 +117,16 @@ int main()
     std::cout << "Starting the final stage." << std::endl;
     while (true)
     {
-        if (enable_monitoring == "true")
+        if (enable_monitoring)
         {
             // Generate a payload message with a timestamp to measure the duration.
-            msg = monitoring::generate_payload();
+            msg.clear();
+            while(msg.length() + MAXDATASIZE < UDP_BUFSIZE)
+            {
+              char buf[MAXDATASIZE];
+              monitoring::generate_payload(buf);
+              msg += buf;
+            }
         }
 
         // Send data to UDP server. Returns -1 on error.
@@ -111,7 +136,7 @@ int main()
         if (bytes_send == -1)
         {
             std::cout << "failed to send a message to the server." << std::endl;
-            exit(1);
+            return 1;
         }
     }
 


### PR DESCRIPTION
This optimizes the TCP vs UDP benchmark. I don't know how to use prometheus so I haven't benchmarked it myself but TCP will likely have a minor improvement while UDP throughput should increase greatly.

The largest optimization is batching several requests together into one call of `send`/`recv`, which will cause UDP to only send 1 packet for several requests and should reduce the number of syscalls and context switches for both tests. The kernel will already batch the TCP requests together into one packet before its sent out before this change which is likely the primary cause for the massive throughput difference between TCP and UDP.

There are other minor changes that will probably marginally increase performance for both tests and I fixed all the compiler warnings I was getting with `-Wall -Wextra -Wpedantic` on gcc. Note that the `UDP_BUFSIZE` define in `monitoring.hpp` can be changed to be much larger when testing on `localhost` vs over a network.