### PR TITLE
perf: pass Device by value

### DIFF
--- a/lessons/215/go-app/main.go
+++ b/lessons/215/go-app/main.go
@@ -50,5 +50,5 @@ func (ms *MyServer) getHealth(w http.ResponseWriter, req *http.Request) {
 func (ms *MyServer) getDevices(w http.ResponseWriter, req *http.Request) {
 	device := Device{Id: 1, Mac: "EF-2B-C4-F5-D6-34", Firmware: "2.1.5"}
 
-	renderJSON(w, &device, 200)
+	renderJSON(w, device, 200)
 }

--- a/lessons/215/go-app/main_bench_test.go
+++ b/lessons/215/go-app/main_bench_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func BenchmarkGetDevicesParallel(b *testing.B) {
+	ms := &MyServer{}
+	b.ReportAllocs()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := httptest.NewRequest("GET", "/api/devices", nil)
+			rec := httptest.NewRecorder()
+
+			ms.getDevices(rec, req)
+
+			res := rec.Result()
+			if res.StatusCode != http.StatusOK {
+				b.Fatalf("expected status %d, got %d", http.StatusOK, res.StatusCode)
+			}
+			res.Body.Close()
+		}
+	})
+}


### PR DESCRIPTION
It looks like Rust app allocates device on stack whereas Go app allocates on heap, lets fix this
```
./main.go:51:2: moved to heap: device
```
This trivial change gives us ~4% cpu time boost and ~7% less memory allocations
```
╰─⠠⠵ benchstat old.txt new.txt                                                             
goos: darwin
goarch: arm64
pkg: go-app
cpu: Apple M3 Max
                      │   old.txt   │              new.txt               │
                      │   sec/op    │   sec/op     vs base               │
GetDevicesParallel-16   2.061µ ± 3%   1.976µ ± 2%  -4.12% (p=0.000 n=15)

                      │   old.txt    │               new.txt               │
                      │     B/op     │     B/op      vs base               │
GetDevicesParallel-16   6.369Ki ± 0%   6.312Ki ± 0%  -0.90% (p=0.000 n=15)

                      │  old.txt   │              new.txt              │
                      │ allocs/op  │ allocs/op   vs base               │
GetDevicesParallel-16   26.00 ± 0%   24.00 ± 0%  -7.69% (p=0.000 n=15)
```

tested on 
```
go version go1.25.4 darwin/arm64
```