### PR TITLE
fix: correct helm provider kubernetes block syntax

### DIFF
--- a/lessons/196/terraform/11-helm-provider.tf
+++ b/lessons/196/terraform/11-helm-provider.tf
@@ -7,7 +7,7 @@ data "aws_eks_cluster_auth" "eks" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.eks.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.eks.token


### PR DESCRIPTION
This PR updates the helm provider configuration to be compatible with v3.0.0, which has introduced breaking changes to the provider syntax.

Reference: https://github.com/hashicorp/terraform-provider-helm/pull/1559/commits/5a43269fe9c37d4824171ddd44bd2d44347fbe89